### PR TITLE
feat(icons): add jellyfin-vue .svg

### DIFF
--- a/svg/jellyfin-vue.svg
+++ b/svg/jellyfin-vue.svg
@@ -1,0 +1,22 @@
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" id="icon-solid-vue" version="1.1" viewBox="23.27 23.27 465.45 465.43">
+  <metadata id="metadata44">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>icon-solid-vue</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id="defs33">
+    <linearGradient id="linear-gradient" x1="110.25" y1="213.3" x2="496.14" y2="436.09" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#41b883" id="stop28"/>
+      <stop offset="1" stop-color="#34495e" id="stop30"/>
+    </linearGradient>
+  </defs>
+  <title id="title35">icon-solid-vue</title>
+  <g id="icon-solid">
+    <path id="inner-shape" d="M256,201.62c-20.44,0-86.23,119.29-76.2,139.43s142.48,19.92,152.4,0S276.47,201.63,256,201.62Z" fill="url(#linear-gradient)"/>
+    <path id="outer-shape" d="M256,23.3C194.44,23.3-3.82,382.73,26.41,443.43s429.34,60,459.24,0S317.62,23.3,256,23.3ZM406.51,390.76c-19.59,39.33-281.08,39.77-300.89,0S215.71,115.48,256.06,115.48,426.1,351.42,406.51,390.76Z" fill="url(#linear-gradient)"/>
+  </g>
+</svg>


### PR DESCRIPTION
The .svg format was missing, so I added the one from the jellyfin vue repo.