### PR TITLE
fix(metadata): align color scheme of icons to look good for background

### DIFF
--- a/meta/1password.json
+++ b/meta/1password.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "1password-dark",
-    "light": "1password"
+    "dark": "1password",
+    "light": "1password-dark"
   }
 }

--- a/meta/2fauth.json
+++ b/meta/2fauth.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "2fauth",
-    "light": "2fauth-light"
+    "dark": "2fauth-light",
+    "light": "2fauth"
   }
 }

--- a/meta/3cx.json
+++ b/meta/3cx.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "3cx",
-    "light": "3cx-light"
+    "dark": "3cx-light",
+    "light": "3cx"
   }
 }

--- a/meta/affine.json
+++ b/meta/affine.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "affine",
-    "light": "affine-light"
+    "dark": "affine-light",
+    "light": "affine"
   }
 }

--- a/meta/akkoma.json
+++ b/meta/akkoma.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "akkoma",
-    "light": "akkoma-light"
+    "dark": "akkoma-light",
+    "light": "akkoma"
   }
 }

--- a/meta/alltube.json
+++ b/meta/alltube.json
@@ -14,7 +14,7 @@
     }
   },
   "colors": {
-    "dark": "alltube",
-    "light": "alltube-light"
+    "dark": "alltube-light",
+    "light": "alltube"
   }
 }

--- a/meta/amazon-web-services.json
+++ b/meta/amazon-web-services.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "amazon-web-services",
-    "light": "amazon-web-services-light"
+    "dark": "amazon-web-services-light",
+    "light": "amazon-web-services"
   }
 }

--- a/meta/amazon.json
+++ b/meta/amazon.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "amazon",
-    "light": "amazon-light"
+    "dark": "amazon-light",
+    "light": "amazon"
   }
 }

--- a/meta/amd.json
+++ b/meta/amd.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "amd",
-    "light": "amd-light"
+    "dark": "amd-light",
+    "light": "amd"
   }
 }

--- a/meta/ami-alt.json
+++ b/meta/ami-alt.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "ami-alt",
-    "light": "ami-alt-light"
+    "dark": "ami-alt-light",
+    "light": "ami-alt"
   }
 }

--- a/meta/android-auto.json
+++ b/meta/android-auto.json
@@ -12,7 +12,7 @@
     }
   },
   "colors": {
-    "dark": "android-auto-dark",
-    "light": "android-auto"
+    "dark": "android-auto",
+    "light": "android-auto-dark"
   }
 }

--- a/meta/ansible.json
+++ b/meta/ansible.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "ansible",
-    "light": "ansible-light"
+    "dark": "ansible-light",
+    "light": "ansible"
   }
 }

--- a/meta/anything-llm.json
+++ b/meta/anything-llm.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "anything-llm",
-    "light": "anything-llm-light"
+    "dark": "anything-llm-light",
+    "light": "anything-llm"
   }
 }

--- a/meta/apache-tomcat.json
+++ b/meta/apache-tomcat.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "apache-tomcat",
-    "light": "apache-tomcat-light"
+    "dark": "apache-tomcat-light",
+    "light": "apache-tomcat"
   }
 }

--- a/meta/apple-tv-plus.json
+++ b/meta/apple-tv-plus.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "apple-tv-plus",
-    "light": "apple-tv-plus-light"
+    "dark": "apple-tv-plus-light",
+    "light": "apple-tv-plus"
   }
 }

--- a/meta/archiveteam-warrior.json
+++ b/meta/archiveteam-warrior.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "archiveteam-warrior",
-    "light": "archiveteam-warrior-light"
+    "dark": "archiveteam-warrior-light",
+    "light": "archiveteam-warrior"
   }
 }

--- a/meta/arris.json
+++ b/meta/arris.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "arris",
-    "light": "arris-light"
+    "dark": "arris-light",
+    "light": "arris"
   }
 }

--- a/meta/astuto.json
+++ b/meta/astuto.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "astuto",
-    "light": "astuto-light"
+    "dark": "astuto-light",
+    "light": "astuto"
   }
 }

--- a/meta/atuin.json
+++ b/meta/atuin.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "atuin",
-    "light": "atuin-light"
+    "dark": "atuin-light",
+    "light": "atuin"
   }
 }

--- a/meta/automad.json
+++ b/meta/automad.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "automad",
-    "light": "automad-light"
+    "dark": "automad-light",
+    "light": "automad"
   }
 }

--- a/meta/aws.json
+++ b/meta/aws.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "aws",
-    "light": "aws-light"
+    "dark": "aws-light",
+    "light": "aws"
   }
 }

--- a/meta/backrest.json
+++ b/meta/backrest.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "backrest",
-    "light": "backrest-light"
+    "dark": "backrest-light",
+    "light": "backrest"
   }
 }

--- a/meta/beaver-habit-tracker.json
+++ b/meta/beaver-habit-tracker.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "beaver-habit-tracker",
-    "light": "beaver-habit-tracker-light"
+    "dark": "beaver-habit-tracker-light",
+    "light": "beaver-habit-tracker"
   }
 }

--- a/meta/beef.json
+++ b/meta/beef.json
@@ -14,7 +14,7 @@
     }
   },
   "colors": {
-    "dark": "beef",
-    "light": "beef-light"
+    "dark": "beef-light",
+    "light": "beef"
   }
 }

--- a/meta/biblioreads.json
+++ b/meta/biblioreads.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "biblioreads",
-    "light": "biblioreads-light"
+    "dark": "biblioreads-light",
+    "light": "biblioreads"
   }
 }

--- a/meta/booklogr.json
+++ b/meta/booklogr.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "booklogr",
-    "light": "booklogr-light"
+    "dark": "booklogr-light",
+    "light": "booklogr"
   }
 }

--- a/meta/borgmatic.json
+++ b/meta/borgmatic.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "borgmatic",
-    "light": "borgmatic-light"
+    "dark": "borgmatic-light",
+    "light": "borgmatic"
   }
 }

--- a/meta/broadcastchannel.json
+++ b/meta/broadcastchannel.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "broadcastchannel",
-    "light": "broadcastchannel-light"
+    "dark": "broadcastchannel-light",
+    "light": "broadcastchannel"
   }
 }

--- a/meta/browserless.json
+++ b/meta/browserless.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "browserless",
-    "light": "browserless-light"
+    "dark": "browserless-light",
+    "light": "browserless"
   }
 }

--- a/meta/budgetbee.json
+++ b/meta/budgetbee.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "budgetbee",
-    "light": "budgetbee-light"
+    "dark": "budgetbee-light",
+    "light": "budgetbee"
   }
 }

--- a/meta/cal-com.json
+++ b/meta/cal-com.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cal-com",
-    "light": "cal-com-light"
+    "dark": "cal-com-light",
+    "light": "cal-com"
   }
 }

--- a/meta/cardigann.json
+++ b/meta/cardigann.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cardigann",
-    "light": "cardigann-light"
+    "dark": "cardigann-light",
+    "light": "cardigann"
   }
 }

--- a/meta/cc.json
+++ b/meta/cc.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cc",
-    "light": "cc-light"
+    "dark": "cc-light",
+    "light": "cc"
   }
 }

--- a/meta/chromecast.json
+++ b/meta/chromecast.json
@@ -13,7 +13,7 @@
     }
   },
   "colors": {
-    "dark": "chromecast",
-    "light": "chromecast-light"
+    "dark": "chromecast-light",
+    "light": "chromecast"
   }
 }

--- a/meta/cilium.json
+++ b/meta/cilium.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cilium",
-    "light": "cilium-light"
+    "dark": "cilium-light",
+    "light": "cilium"
   }
 }

--- a/meta/cinny.json
+++ b/meta/cinny.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "cinny",
-    "light": "cinny-light"
+    "dark": "cinny-light",
+    "light": "cinny"
   }
 }

--- a/meta/cloud9.json
+++ b/meta/cloud9.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "cloud9",
-    "light": "cloud9-light"
+    "dark": "cloud9-light",
+    "light": "cloud9"
   }
 }

--- a/meta/cockpit-cms.json
+++ b/meta/cockpit-cms.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cockpit-cms",
-    "light": "cockpit-cms-light"
+    "dark": "cockpit-cms-light",
+    "light": "cockpit-cms"
   }
 }

--- a/meta/cockpit.json
+++ b/meta/cockpit.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cockpit",
-    "light": "cockpit-light"
+    "dark": "cockpit-light",
+    "light": "cockpit"
   }
 }

--- a/meta/coder.json
+++ b/meta/coder.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "coder",
-    "light": "coder-light"
+    "dark": "coder-light",
+    "light": "coder"
   }
 }

--- a/meta/codestats.json
+++ b/meta/codestats.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "codestats",
-    "light": "codestats-light"
+    "dark": "codestats-light",
+    "light": "codestats"
   }
 }

--- a/meta/codimd.json
+++ b/meta/codimd.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "codimd",
-    "light": "codimd-light"
+    "dark": "codimd-light",
+    "light": "codimd"
   }
 }

--- a/meta/commento.json
+++ b/meta/commento.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "commento",
-    "light": "commento-light"
+    "dark": "commento-light",
+    "light": "commento"
   }
 }

--- a/meta/converse.json
+++ b/meta/converse.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "converse",
-    "light": "converse-light"
+    "dark": "converse-light",
+    "light": "converse"
   }
 }

--- a/meta/cribl.json
+++ b/meta/cribl.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cribl",
-    "light": "cribl-light"
+    "dark": "cribl-light",
+    "light": "cribl"
   }
 }

--- a/meta/css.json
+++ b/meta/css.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "css",
-    "light": "css-light"
+    "dark": "css-light",
+    "light": "css"
   }
 }

--- a/meta/cups.json
+++ b/meta/cups.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "cups",
-    "light": "cups-light"
+    "dark": "cups-light",
+    "light": "cups"
   }
 }

--- a/meta/dd-wrt.json
+++ b/meta/dd-wrt.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "dd-wrt",
-    "light": "dd-wrt-light"
+    "dark": "dd-wrt-light",
+    "light": "dd-wrt"
   }
 }

--- a/meta/deno.json
+++ b/meta/deno.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "deno",
-    "light": "deno-light"
+    "dark": "deno-light",
+    "light": "deno"
   }
 }

--- a/meta/denon.json
+++ b/meta/denon.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "denon",
-    "light": "denon-light"
+    "dark": "denon-light",
+    "light": "denon"
   }
 }

--- a/meta/devtooly.json
+++ b/meta/devtooly.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "devtooly",
-    "light": "devtooly-light"
+    "dark": "devtooly-light",
+    "light": "devtooly"
   }
 }

--- a/meta/dillinger.json
+++ b/meta/dillinger.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "dillinger",
-    "light": "dillinger-light"
+    "dark": "dillinger-light",
+    "light": "dillinger"
   }
 }

--- a/meta/dim.json
+++ b/meta/dim.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "dim",
-    "light": "dim-light"
+    "dark": "dim-light",
+    "light": "dim"
   }
 }

--- a/meta/discourse.json
+++ b/meta/discourse.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "discourse",
-    "light": "discourse-light"
+    "dark": "discourse-light",
+    "light": "discourse"
   }
 }

--- a/meta/docassemble.json
+++ b/meta/docassemble.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "docassemble",
-    "light": "docassemble-light"
+    "dark": "docassemble-light",
+    "light": "docassemble"
   }
 }

--- a/meta/docker-mailserver.json
+++ b/meta/docker-mailserver.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "docker-mailserver",
-    "light": "docker-mailserver-light"
+    "dark": "docker-mailserver-light",
+    "light": "docker-mailserver"
   }
 }

--- a/meta/double-take.json
+++ b/meta/double-take.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "double-take-dark",
-    "light": "double-take"
+    "dark": "double-take",
+    "light": "double-take-dark"
   }
 }

--- a/meta/dub.json
+++ b/meta/dub.json
@@ -12,7 +12,7 @@
     }
   },
   "colors": {
-    "dark": "dub",
-    "light": "dub-light"
+    "dark": "dub-light",
+    "light": "dub"
   }
 }

--- a/meta/easy-gate.json
+++ b/meta/easy-gate.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "easy-gate",
-    "light": "easy-gate-light"
+    "dark": "easy-gate-light",
+    "light": "easy-gate"
   }
 }

--- a/meta/edgeos.json
+++ b/meta/edgeos.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "edgeos",
-    "light": "edgeos-light"
+    "dark": "edgeos-light",
+    "light": "edgeos"
   }
 }

--- a/meta/eleventy.json
+++ b/meta/eleventy.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "eleventy",
-    "light": "eleventy-light"
+    "dark": "eleventy-light",
+    "light": "eleventy"
   }
 }

--- a/meta/emq.json
+++ b/meta/emq.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "emq",
-    "light": "emq-light"
+    "dark": "emq-light",
+    "light": "emq"
   }
 }

--- a/meta/enclosed.json
+++ b/meta/enclosed.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "enclosed",
-    "light": "enclosed-light"
+    "dark": "enclosed-light",
+    "light": "enclosed"
   }
 }

--- a/meta/endless.json
+++ b/meta/endless.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "endless",
-    "light": "endless-light"
+    "dark": "endless-light",
+    "light": "endless"
   }
 }

--- a/meta/epic-games.json
+++ b/meta/epic-games.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "epic-games",
-    "light": "epic-games-light"
+    "dark": "epic-games-light",
+    "light": "epic-games"
   }
 }

--- a/meta/esphome-alt.json
+++ b/meta/esphome-alt.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "esphome-alt",
-    "light": "esphome-alt-light"
+    "dark": "esphome-alt-light",
+    "light": "esphome-alt"
   }
 }

--- a/meta/esphome.json
+++ b/meta/esphome.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "esphome",
-    "light": "esphome-light"
+    "dark": "esphome-light",
+    "light": "esphome"
   }
 }

--- a/meta/fast-com.json
+++ b/meta/fast-com.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "fast-com",
-    "light": "fast-com-light"
+    "dark": "fast-com-light",
+    "light": "fast-com"
   }
 }

--- a/meta/feedbase.json
+++ b/meta/feedbase.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "feedbase",
-    "light": "feedbase-light"
+    "dark": "feedbase-light",
+    "light": "feedbase"
   }
 }

--- a/meta/feedbin.json
+++ b/meta/feedbin.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "feedbin",
-    "light": "feedbin-light"
+    "dark": "feedbin-light",
+    "light": "feedbin"
   }
 }

--- a/meta/feedlynx.json
+++ b/meta/feedlynx.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "feedlynx",
-    "light": "feedlynx-light"
+    "dark": "feedlynx-light",
+    "light": "feedlynx"
   }
 }

--- a/meta/fenrus.json
+++ b/meta/fenrus.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "light": "fenrus-light",
-    "dark": "fenrus"
+    "light": "fenrus",
+    "dark": "fenrus-light"
   }
 }

--- a/meta/fios.json
+++ b/meta/fios.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "fios",
-    "light": "fios-light"
+    "dark": "fios-light",
+    "light": "fios"
   }
 }

--- a/meta/flightradar24.json
+++ b/meta/flightradar24.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "flightradar24",
-    "light": "flightradar24-light"
+    "dark": "flightradar24-light",
+    "light": "flightradar24"
   }
 }

--- a/meta/forte.json
+++ b/meta/forte.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "forte",
-    "light": "forte-light"
+    "dark": "forte-light",
+    "light": "forte"
   }
 }

--- a/meta/frigate.json
+++ b/meta/frigate.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "frigate",
-    "light": "frigate-light"
+    "dark": "frigate-light",
+    "light": "frigate"
   }
 }

--- a/meta/funkwhale.json
+++ b/meta/funkwhale.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "funkwhale",
-    "light": "funkwhale-light"
+    "dark": "funkwhale-light",
+    "light": "funkwhale"
   }
 }

--- a/meta/fusionauth.json
+++ b/meta/fusionauth.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "light": "fusionauth-light",
-    "dark": "fusionauth"
+    "light": "fusionauth",
+    "dark": "fusionauth-light"
   }
 }

--- a/meta/gameyfin.json
+++ b/meta/gameyfin.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "gameyfin",
-    "light": "gameyfin-light"
+    "dark": "gameyfin-light",
+    "light": "gameyfin"
   }
 }

--- a/meta/ghost.json
+++ b/meta/ghost.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "ghost",
-    "light": "ghost-light"
+    "dark": "ghost-light",
+    "light": "ghost"
   }
 }

--- a/meta/github.json
+++ b/meta/github.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "github",
-    "light": "github-light"
+    "dark": "github-light",
+    "light": "github"
   }
 }

--- a/meta/glance.json
+++ b/meta/glance.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "glance",
-    "light": "glance-light"
+    "dark": "glance-light",
+    "light": "glance"
   }
 }

--- a/meta/glances.json
+++ b/meta/glances.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "glances",
-    "light": "glances-light"
+    "dark": "glances-light",
+    "light": "glances"
   }
 }

--- a/meta/goaccess.json
+++ b/meta/goaccess.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "goaccess",
-    "light": "goaccess-light"
+    "dark": "goaccess-light",
+    "light": "goaccess"
   }
 }

--- a/meta/grav.json
+++ b/meta/grav.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "grav",
-    "light": "grav-light"
+    "dark": "grav-light",
+    "light": "grav"
   }
 }

--- a/meta/greenbone.json
+++ b/meta/greenbone.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "greenbone",
-    "light": "greenbone-light"
+    "dark": "greenbone-light",
+    "light": "greenbone"
   }
 }

--- a/meta/guacamole.json
+++ b/meta/guacamole.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "guacamole",
-    "light": "guacamole-light"
+    "dark": "guacamole-light",
+    "light": "guacamole"
   }
 }

--- a/meta/hammond.json
+++ b/meta/hammond.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "hammond",
-    "light": "hammond-light"
+    "dark": "hammond-light",
+    "light": "hammond"
   }
 }

--- a/meta/haptic.json
+++ b/meta/haptic.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "haptic",
-    "light": "haptic-light"
+    "dark": "haptic-light",
+    "light": "haptic"
   }
 }

--- a/meta/hatsh.json
+++ b/meta/hatsh.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "hatsh",
-    "light": "hatsh-light"
+    "dark": "hatsh-light",
+    "light": "hatsh"
   }
 }

--- a/meta/hbo.json
+++ b/meta/hbo.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "hbo",
-    "light": "hbo-light"
+    "dark": "hbo-light",
+    "light": "hbo"
   }
 }

--- a/meta/heimdall.json
+++ b/meta/heimdall.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "heimdall",
-    "light": "heimdall-light"
+    "dark": "heimdall-light",
+    "light": "heimdall"
   }
 }

--- a/meta/hemmelig.json
+++ b/meta/hemmelig.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "hemmelig",
-    "light": "hemmelig-light"
+    "dark": "hemmelig-light",
+    "light": "hemmelig"
   }
 }

--- a/meta/hoarder.json
+++ b/meta/hoarder.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "hoarder",
-    "light": "hoarder-light"
+    "dark": "hoarder-light",
+    "light": "hoarder"
   }
 }

--- a/meta/hollo.json
+++ b/meta/hollo.json
@@ -12,7 +12,7 @@
     }
   },
   "colors": {
-    "dark": "hollo",
-    "light": "hollo-light"
+    "dark": "hollo-light",
+    "light": "hollo"
   }
 }

--- a/meta/homebox.json
+++ b/meta/homebox.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "homebox",
-    "light": "homebox-light"
+    "dark": "homebox-light",
+    "light": "homebox"
   }
 }

--- a/meta/html.json
+++ b/meta/html.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "html",
-    "light": "html-light"
+    "dark": "html-light",
+    "light": "html"
   }
 }

--- a/meta/hyperpipe.json
+++ b/meta/hyperpipe.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "hyperpipe",
-    "light": "hyperpipe-light"
+    "dark": "hyperpipe-light",
+    "light": "hyperpipe"
   }
 }

--- a/meta/i2p.json
+++ b/meta/i2p.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "i2p",
-    "light": "i2p-light"
+    "dark": "i2p-light",
+    "light": "i2p"
   }
 }

--- a/meta/icinga-full.json
+++ b/meta/icinga-full.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "icinga-full",
-    "light": "icinga-full-light"
+    "dark": "icinga-full-light",
+    "light": "icinga-full"
   }
 }

--- a/meta/icinga.json
+++ b/meta/icinga.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "icinga",
-    "light": "icinga-light"
+    "dark": "icinga-light",
+    "light": "icinga"
   }
 }

--- a/meta/immich-frame.json
+++ b/meta/immich-frame.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "immich-frame",
-    "light": "immich-frame-light"
+    "dark": "immich-frame-light",
+    "light": "immich-frame"
   }
 }

--- a/meta/infomaniak-kdrive.json
+++ b/meta/infomaniak-kdrive.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "infomaniak-kdrive-dark",
-    "light": "infomaniak-kdrive-light"
+    "dark": "infomaniak-kdrive-light",
+    "light": "infomaniak-kdrive-dark"
   }
 }

--- a/meta/infomaniak-kmeet.json
+++ b/meta/infomaniak-kmeet.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "infomaniak-kmeet-dark",
-    "light": "infomaniak-kmeet-light"
+    "dark": "infomaniak-kmeet-light",
+    "light": "infomaniak-kmeet-dark"
   }
 }

--- a/meta/infomaniak-swisstransfer.json
+++ b/meta/infomaniak-swisstransfer.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "infomaniak-swisstransfer-dark",
-    "light": "infomaniak-swisstransfer-light"
+    "dark": "infomaniak-swisstransfer-light",
+    "light": "infomaniak-swisstransfer-dark"
   }
 }

--- a/meta/invoice-ninja.json
+++ b/meta/invoice-ninja.json
@@ -13,7 +13,7 @@
     }
   },
   "colors": {
-    "dark": "invoice-ninja",
-    "light": "invoice-ninja-light"
+    "dark": "invoice-ninja-light",
+    "light": "invoice-ninja"
   }
 }

--- a/meta/invoiceninja.json
+++ b/meta/invoiceninja.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "invoiceninja",
-    "light": "invoiceninja-light"
+    "dark": "invoiceninja-light",
+    "light": "invoiceninja"
   }
 }

--- a/meta/it-tools.json
+++ b/meta/it-tools.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "it-tools",
-    "light": "it-tools-light"
+    "dark": "it-tools-light",
+    "light": "it-tools"
   }
 }

--- a/meta/jackett.json
+++ b/meta/jackett.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "jackett",
-    "light": "jackett-light"
+    "dark": "jackett-light",
+    "light": "jackett"
   }
 }

--- a/meta/jwt-io.json
+++ b/meta/jwt-io.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "jwt-io",
-    "light": "jwt-io-light"
+    "dark": "jwt-io-light",
+    "light": "jwt-io"
   }
 }

--- a/meta/kanboard.json
+++ b/meta/kanboard.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "kanboard",
-    "light": "kanboard-light"
+    "dark": "kanboard-light",
+    "light": "kanboard"
   }
 }

--- a/meta/karakeep.json
+++ b/meta/karakeep.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "light": "karakeep",
-    "dark": "karakeep-dark"
+    "light": "karakeep-dark",
+    "dark": "karakeep"
   }
 }

--- a/meta/kick.json
+++ b/meta/kick.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "kick",
-    "light": "kick-light"
+    "dark": "kick-light",
+    "light": "kick"
   }
 }

--- a/meta/kiwix.json
+++ b/meta/kiwix.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "kiwix",
-    "light": "kiwix-light"
+    "dark": "kiwix-light",
+    "light": "kiwix"
   }
 }

--- a/meta/koillection.json
+++ b/meta/koillection.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "koillection",
-    "light": "koillection-light"
+    "dark": "koillection-light",
+    "light": "koillection"
   }
 }

--- a/meta/lancommander.json
+++ b/meta/lancommander.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "lancommander",
-    "light": "lancommander-light"
+    "dark": "lancommander-light",
+    "light": "lancommander"
   }
 }

--- a/meta/lemmy.json
+++ b/meta/lemmy.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "lemmy",
-    "light": "lemmy-light"
+    "dark": "lemmy-light",
+    "light": "lemmy"
   }
 }

--- a/meta/libreddit.json
+++ b/meta/libreddit.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "libreddit",
-    "light": "libreddit-light"
+    "dark": "libreddit-light",
+    "light": "libreddit"
   }
 }

--- a/meta/libreoffice.json
+++ b/meta/libreoffice.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "libreoffice",
-    "light": "libreoffice-light"
+    "dark": "libreoffice-light",
+    "light": "libreoffice"
   }
 }

--- a/meta/locals.json
+++ b/meta/locals.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "locals",
-    "light": "locals-light"
+    "dark": "locals-light",
+    "light": "locals"
   }
 }

--- a/meta/logitech.json
+++ b/meta/logitech.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "logitech",
-    "light": "logitech-light"
+    "dark": "logitech-light",
+    "light": "logitech"
   }
 }

--- a/meta/lynx.json
+++ b/meta/lynx.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "lynx",
-    "light": "lynx-light"
+    "dark": "lynx-light",
+    "light": "lynx"
   }
 }

--- a/meta/lyrion.json
+++ b/meta/lyrion.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "lyrion-dark",
-    "light": "lyrion"
+    "dark": "lyrion",
+    "light": "lyrion-dark"
   }
 }

--- a/meta/mailchimp.json
+++ b/meta/mailchimp.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "mailchimp",
-    "light": "mailchimp-light"
+    "dark": "mailchimp-light",
+    "light": "mailchimp"
   }
 }

--- a/meta/matrix-synapse.json
+++ b/meta/matrix-synapse.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "matrix-synapse",
-    "light": "matrix-synapse-light"
+    "dark": "matrix-synapse-light",
+    "light": "matrix-synapse"
   }
 }

--- a/meta/matrix.json
+++ b/meta/matrix.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "matrix",
-    "light": "matrix-light"
+    "dark": "matrix-light",
+    "light": "matrix"
   }
 }

--- a/meta/matter.json
+++ b/meta/matter.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "matter",
-    "light": "matter-light"
+    "dark": "matter-light",
+    "light": "matter"
   }
 }

--- a/meta/mayan-edms.json
+++ b/meta/mayan-edms.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "mayan-edms",
-    "light": "mayan-edms-light"
+    "dark": "mayan-edms-light",
+    "light": "mayan-edms"
   }
 }

--- a/meta/medium.json
+++ b/meta/medium.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "medium-dark",
-    "light": "medium-light"
+    "dark": "medium-light",
+    "light": "medium-dark"
   }
 }

--- a/meta/medusa.json
+++ b/meta/medusa.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "medusa",
-    "light": "medusa-light"
+    "dark": "medusa-light",
+    "light": "medusa"
   }
 }

--- a/meta/memories.json
+++ b/meta/memories.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "memories",
-    "light": "memories-light"
+    "dark": "memories-light",
+    "light": "memories"
   }
 }

--- a/meta/meshping.json
+++ b/meta/meshping.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "meshping",
-    "light": "meshping-light"
+    "dark": "meshping-light",
+    "light": "meshping"
   }
 }

--- a/meta/microsoft-sql-server.json
+++ b/meta/microsoft-sql-server.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "microsoft-sql-server",
-    "light": "microsoft-sql-server-light"
+    "dark": "microsoft-sql-server-light",
+    "light": "microsoft-sql-server"
   }
 }

--- a/meta/midjourney.json
+++ b/meta/midjourney.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "midjourney",
-    "light": "midjourney-light"
+    "dark": "midjourney-light",
+    "light": "midjourney"
   }
 }

--- a/meta/mikrotik.json
+++ b/meta/mikrotik.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "mikrotik",
-    "light": "mikrotik-light"
+    "dark": "mikrotik-light",
+    "light": "mikrotik"
   }
 }

--- a/meta/miniflux.json
+++ b/meta/miniflux.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "miniflux",
-    "light": "miniflux-light"
+    "dark": "miniflux-light",
+    "light": "miniflux"
   }
 }

--- a/meta/minio.json
+++ b/meta/minio.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "minio",
-    "light": "minio-light"
+    "dark": "minio-light",
+    "light": "minio"
   }
 }

--- a/meta/misskey.json
+++ b/meta/misskey.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "misskey",
-    "light": "misskey-light"
+    "dark": "misskey-light",
+    "light": "misskey"
   }
 }

--- a/meta/mobotix.json
+++ b/meta/mobotix.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "mobotix",
-    "light": "mobotix-light"
+    "dark": "mobotix-light",
+    "light": "mobotix"
   }
 }

--- a/meta/monica.json
+++ b/meta/monica.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "monica",
-    "light": "monica-light"
+    "dark": "monica-light",
+    "light": "monica"
   }
 }

--- a/meta/moodist.json
+++ b/meta/moodist.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "moodist-dark",
-    "light": "moodist"
+    "dark": "moodist",
+    "light": "moodist-dark"
   }
 }

--- a/meta/moodle.json
+++ b/meta/moodle.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "moodle",
-    "light": "moodle-light"
+    "dark": "moodle-light",
+    "light": "moodle"
   }
 }

--- a/meta/music-assistant.json
+++ b/meta/music-assistant.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "music-assistant",
-    "light": "music-assistant-light"
+    "dark": "music-assistant-light",
+    "light": "music-assistant"
   }
 }

--- a/meta/myheats.json
+++ b/meta/myheats.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "myheats",
-    "light": "myheats-light"
+    "dark": "myheats-light",
+    "light": "myheats"
   }
 }

--- a/meta/navidrome.json
+++ b/meta/navidrome.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "navidrome",
-    "light": "navidrome-light"
+    "dark": "navidrome-light",
+    "light": "navidrome"
   }
 }

--- a/meta/neko.json
+++ b/meta/neko.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "neko",
-    "light": "neko-light"
+    "dark": "neko-light",
+    "light": "neko"
   }
 }

--- a/meta/netalertx.json
+++ b/meta/netalertx.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "netalertx",
-    "light": "netalertx-light"
+    "dark": "netalertx-light",
+    "light": "netalertx"
   }
 }

--- a/meta/netapp.json
+++ b/meta/netapp.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "netapp",
-    "light": "netapp-light"
+    "dark": "netapp-light",
+    "light": "netapp"
   }
 }

--- a/meta/netbox-full.json
+++ b/meta/netbox-full.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "netbox-full-dark",
-    "light": "netbox-full"
+    "dark": "netbox-full",
+    "light": "netbox-full-dark"
   }
 }

--- a/meta/netbox.json
+++ b/meta/netbox.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "netbox-dark",
-    "light": "netbox"
+    "dark": "netbox",
+    "light": "netbox-dark"
   }
 }

--- a/meta/netgear.json
+++ b/meta/netgear.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "netgear",
-    "light": "netgear-light"
+    "dark": "netgear-light",
+    "light": "netgear"
   }
 }

--- a/meta/nextjs.json
+++ b/meta/nextjs.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "nextjs",
-    "light": "nextjs-light"
+    "dark": "nextjs-light",
+    "light": "nextjs"
   }
 }

--- a/meta/nightscout.json
+++ b/meta/nightscout.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "nightscout",
-    "light": "nightscout-light"
+    "dark": "nightscout-light",
+    "light": "nightscout"
   }
 }

--- a/meta/nocobase.json
+++ b/meta/nocobase.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "nocobase",
-    "light": "nocobase-light"
+    "dark": "nocobase-light",
+    "light": "nocobase"
   }
 }

--- a/meta/notesnook.json
+++ b/meta/notesnook.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "notesnook",
-    "light": "notesnook-light"
+    "dark": "notesnook-light",
+    "light": "notesnook"
   }
 }

--- a/meta/notion.json
+++ b/meta/notion.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "notion",
-    "light": "notion-light"
+    "dark": "notion-light",
+    "light": "notion"
   }
 }

--- a/meta/nzbhydra2.json
+++ b/meta/nzbhydra2.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "nzbhydra2",
-    "light": "nzbhydra2-light"
+    "dark": "nzbhydra2-light",
+    "light": "nzbhydra2"
   }
 }

--- a/meta/oculus.json
+++ b/meta/oculus.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "oculus",
-    "light": "oculus-light"
+    "dark": "oculus-light",
+    "light": "oculus"
   }
 }

--- a/meta/odysee-full.json
+++ b/meta/odysee-full.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "odysee-full-dark",
-    "light": "odysee-full-light"
+    "dark": "odysee-full-light",
+    "light": "odysee-full-dark"
   }
 }

--- a/meta/olivetin.json
+++ b/meta/olivetin.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "olivetin",
-    "light": "olivetin-light"
+    "dark": "olivetin-light",
+    "light": "olivetin"
   }
 }

--- a/meta/onedev.json
+++ b/meta/onedev.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "onedev",
-    "light": "onedev-light"
+    "dark": "onedev-light",
+    "light": "onedev"
   }
 }

--- a/meta/oneuptime.json
+++ b/meta/oneuptime.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "oneuptime",
-    "light": "oneuptime-light"
+    "dark": "oneuptime-light",
+    "light": "oneuptime"
   }
 }

--- a/meta/open-webui.json
+++ b/meta/open-webui.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "light": "open-webui-light",
-    "dark": "open-webui"
+    "light": "open-webui",
+    "dark": "open-webui-light"
   }
 }

--- a/meta/openai.json
+++ b/meta/openai.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "openai",
-    "light": "openai-light"
+    "dark": "openai-light",
+    "light": "openai"
   }
 }

--- a/meta/openchangelog.json
+++ b/meta/openchangelog.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "openchangelog",
-    "light": "openchangelog-light"
+    "dark": "openchangelog-light",
+    "light": "openchangelog"
   }
 }

--- a/meta/openeats.json
+++ b/meta/openeats.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "openeats",
-    "light": "openeats-light"
+    "dark": "openeats-light",
+    "light": "openeats"
   }
 }

--- a/meta/openemr.json
+++ b/meta/openemr.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "openemr",
-    "light": "openemr-light"
+    "dark": "openemr-light",
+    "light": "openemr"
   }
 }

--- a/meta/opengist.json
+++ b/meta/opengist.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "opengist",
-    "light": "opengist-light"
+    "dark": "opengist-light",
+    "light": "opengist"
   }
 }

--- a/meta/openpanel.json
+++ b/meta/openpanel.json
@@ -14,7 +14,7 @@
     }
   },
   "colors": {
-    "dark": "openpanel",
-    "light": "openpanel-light"
+    "dark": "openpanel-light",
+    "light": "openpanel"
   }
 }

--- a/meta/oscarr.json
+++ b/meta/oscarr.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "oscarr",
-    "light": "oscarr-light"
+    "dark": "oscarr-light",
+    "light": "oscarr"
   }
 }

--- a/meta/outline.json
+++ b/meta/outline.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "outline",
-    "light": "outline-light"
+    "dark": "outline-light",
+    "light": "outline"
   }
 }

--- a/meta/ovirt.json
+++ b/meta/ovirt.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "ovirt",
-    "light": "ovirt-light"
+    "dark": "ovirt-light",
+    "light": "ovirt"
   }
 }

--- a/meta/ownphotos.json
+++ b/meta/ownphotos.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "ownphotos",
-    "light": "ownphotos-light"
+    "dark": "ownphotos-light",
+    "light": "ownphotos"
   }
 }

--- a/meta/oxker.json
+++ b/meta/oxker.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "oxker",
-    "light": "oxker-light"
+    "dark": "oxker-light",
+    "light": "oxker"
   }
 }

--- a/meta/papermark.json
+++ b/meta/papermark.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "papermark",
-    "light": "papermark-light"
+    "dark": "papermark-light",
+    "light": "papermark"
   }
 }

--- a/meta/papermerge.json
+++ b/meta/papermerge.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "papermerge",
-    "light": "papermerge-light"
+    "dark": "papermerge-light",
+    "light": "papermerge"
   }
 }

--- a/meta/part-db.json
+++ b/meta/part-db.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "part-db",
-    "light": "part-db-light"
+    "dark": "part-db-light",
+    "light": "part-db"
   }
 }

--- a/meta/passwordpusher.json
+++ b/meta/passwordpusher.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "passwordpusher",
-    "light": "passwordpusher-light"
+    "dark": "passwordpusher-light",
+    "light": "passwordpusher"
   }
 }

--- a/meta/pastatool.json
+++ b/meta/pastatool.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pastatool",
-    "light": "pastatool-light"
+    "dark": "pastatool-light",
+    "light": "pastatool"
   }
 }

--- a/meta/patreon.json
+++ b/meta/patreon.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "patreon",
-    "light": "patreon-light"
+    "dark": "patreon-light",
+    "light": "patreon"
   }
 }

--- a/meta/payload.json
+++ b/meta/payload.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "payload",
-    "light": "payload-light"
+    "dark": "payload-light",
+    "light": "payload"
   }
 }

--- a/meta/pdfding.json
+++ b/meta/pdfding.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pdfding",
-    "light": "pdfding-light"
+    "dark": "pdfding-light",
+    "light": "pdfding"
   }
 }

--- a/meta/peacock.json
+++ b/meta/peacock.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "peacock",
-    "light": "peacock-light"
+    "dark": "peacock-light",
+    "light": "peacock"
   }
 }

--- a/meta/peanut.json
+++ b/meta/peanut.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "peanut",
-    "light": "peanut-light"
+    "dark": "peanut-light",
+    "light": "peanut"
   }
 }

--- a/meta/penpot.json
+++ b/meta/penpot.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "penpot",
-    "light": "penpot-light"
+    "dark": "penpot-light",
+    "light": "penpot"
   }
 }

--- a/meta/pfsense.json
+++ b/meta/pfsense.json
@@ -18,7 +18,7 @@
     }
   },
   "colors": {
-    "dark": "pfsense",
-    "light": "pfsense-light"
+    "dark": "pfsense-light",
+    "light": "pfsense"
   }
 }

--- a/meta/pgbackweb.json
+++ b/meta/pgbackweb.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pgbackweb-dark",
-    "light": "pgbackweb-light"
+    "dark": "pgbackweb-light",
+    "light": "pgbackweb-dark"
   }
 }

--- a/meta/phoneinfoga.json
+++ b/meta/phoneinfoga.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "phoneinfoga",
-    "light": "phoneinfoga-light"
+    "dark": "phoneinfoga-light",
+    "light": "phoneinfoga"
   }
 }

--- a/meta/phorge.json
+++ b/meta/phorge.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "phorge",
-    "light": "phorge-light"
+    "dark": "phorge-light",
+    "light": "phorge"
   }
 }

--- a/meta/phoscon.json
+++ b/meta/phoscon.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "phoscon",
-    "light": "phoscon-light"
+    "dark": "phoscon-light",
+    "light": "phoscon"
   }
 }

--- a/meta/photonix.json
+++ b/meta/photonix.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "photonix",
-    "light": "photonix-light"
+    "dark": "photonix-light",
+    "light": "photonix"
   }
 }

--- a/meta/picsur.json
+++ b/meta/picsur.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "picsur",
-    "light": "picsur-light"
+    "dark": "picsur-light",
+    "light": "picsur"
   }
 }

--- a/meta/pikvm.json
+++ b/meta/pikvm.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "light": "pikvm-light",
-    "dark": "pikvm"
+    "light": "pikvm",
+    "dark": "pikvm-light"
   }
 }

--- a/meta/pingdom.json
+++ b/meta/pingdom.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pingdom",
-    "light": "pingdom-light"
+    "dark": "pingdom-light",
+    "light": "pingdom"
   }
 }

--- a/meta/pioneer.json
+++ b/meta/pioneer.json
@@ -12,7 +12,7 @@
     }
   },
   "colors": {
-    "dark": "pioneer",
-    "light": "pioneer-light"
+    "dark": "pioneer-light",
+    "light": "pioneer"
   }
 }

--- a/meta/planka.json
+++ b/meta/planka.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "planka-dark",
-    "light": "planka"
+    "dark": "planka",
+    "light": "planka-dark"
   }
 }

--- a/meta/plex-alt.json
+++ b/meta/plex-alt.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "plex-alt",
-    "light": "plex-alt-light"
+    "dark": "plex-alt-light",
+    "light": "plex-alt"
   }
 }

--- a/meta/plex-meta-manager.json
+++ b/meta/plex-meta-manager.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "plex-meta-manager",
-    "light": "plex-meta-manager-light"
+    "dark": "plex-meta-manager-light",
+    "light": "plex-meta-manager"
   }
 }

--- a/meta/plex.json
+++ b/meta/plex.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "plex",
-    "light": "plex-light"
+    "dark": "plex-light",
+    "light": "plex"
   }
 }

--- a/meta/pocket-id.json
+++ b/meta/pocket-id.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pocket-id",
-    "light": "pocket-id-light"
+    "dark": "pocket-id-light",
+    "light": "pocket-id"
   }
 }

--- a/meta/podfetch.json
+++ b/meta/podfetch.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "podfetch",
-    "light": "podfetch-light"
+    "dark": "podfetch-light",
+    "light": "podfetch"
   }
 }

--- a/meta/posthog.json
+++ b/meta/posthog.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "posthog",
-    "light": "posthog-light"
+    "dark": "posthog-light",
+    "light": "posthog"
   }
 }

--- a/meta/prime-video.json
+++ b/meta/prime-video.json
@@ -12,7 +12,7 @@
     }
   },
   "colors": {
-    "dark": "prime-video",
-    "light": "prime-video-light"
+    "dark": "prime-video-light",
+    "light": "prime-video"
   }
 }

--- a/meta/proxmox.json
+++ b/meta/proxmox.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "proxmox",
-    "light": "proxmox-light"
+    "dark": "proxmox-light",
+    "light": "proxmox"
   }
 }

--- a/meta/pwndrop.json
+++ b/meta/pwndrop.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pwndrop",
-    "light": "pwndrop-light"
+    "dark": "pwndrop-light",
+    "light": "pwndrop"
   }
 }

--- a/meta/pwpush.json
+++ b/meta/pwpush.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "pwpush",
-    "light": "pwpush-light"
+    "dark": "pwpush-light",
+    "light": "pwpush"
   }
 }

--- a/meta/raritan.json
+++ b/meta/raritan.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "raritan",
-    "light": "raritan-light"
+    "dark": "raritan-light",
+    "light": "raritan"
   }
 }

--- a/meta/raspberry-pi.json
+++ b/meta/raspberry-pi.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "raspberry-pi",
-    "light": "raspberry-pi-light"
+    "dark": "raspberry-pi-light",
+    "light": "raspberry-pi"
   }
 }

--- a/meta/reactive-resume.json
+++ b/meta/reactive-resume.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "reactive-resume",
-    "light": "reactive-resume-light"
+    "dark": "reactive-resume-light",
+    "light": "reactive-resume"
   }
 }

--- a/meta/readthedocs.json
+++ b/meta/readthedocs.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "readthedocs",
-    "light": "readthedocs-light"
+    "dark": "readthedocs-light",
+    "light": "readthedocs"
   }
 }

--- a/meta/redlib.json
+++ b/meta/redlib.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "redlib",
-    "light": "redlib-light"
+    "dark": "redlib-light",
+    "light": "redlib"
   }
 }

--- a/meta/revolt.json
+++ b/meta/revolt.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "revolt",
-    "light": "revolt-light"
+    "dark": "revolt-light",
+    "light": "revolt"
   }
 }

--- a/meta/rhasspy.json
+++ b/meta/rhasspy.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "rhasspy-dark",
-    "light": "rhasspy"
+    "dark": "rhasspy",
+    "light": "rhasspy-dark"
   }
 }

--- a/meta/rimgo.json
+++ b/meta/rimgo.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "rimgo",
-    "light": "rimgo-light"
+    "dark": "rimgo-light",
+    "light": "rimgo"
   }
 }

--- a/meta/riverside-fm.json
+++ b/meta/riverside-fm.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "riverside-fm",
-    "light": "riverside-fm-light"
+    "dark": "riverside-fm-light",
+    "light": "riverside-fm"
   }
 }

--- a/meta/runson.json
+++ b/meta/runson.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "runson",
-    "light": "runson-light"
+    "dark": "runson-light",
+    "light": "runson"
   }
 }

--- a/meta/ryot.json
+++ b/meta/ryot.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "ryot",
-    "light": "ryot-light"
+    "dark": "ryot-light",
+    "light": "ryot"
   }
 }

--- a/meta/sabnzbd.json
+++ b/meta/sabnzbd.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "sabnzbd",
-    "light": "sabnzbd-light"
+    "dark": "sabnzbd-light",
+    "light": "sabnzbd"
   }
 }

--- a/meta/secureai-tools.json
+++ b/meta/secureai-tools.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "secureai-tools",
-    "light": "secureai-tools-light"
+    "dark": "secureai-tools-light",
+    "light": "secureai-tools"
   }
 }

--- a/meta/selfh-st.json
+++ b/meta/selfh-st.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "selfh-st",
-    "light": "selfh-st-light"
+    "dark": "selfh-st-light",
+    "light": "selfh-st"
   }
 }

--- a/meta/selfhosted.json
+++ b/meta/selfhosted.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "selfhosted",
-    "light": "selfhosted-light"
+    "dark": "selfhosted-light",
+    "light": "selfhosted"
   }
 }

--- a/meta/sentry.json
+++ b/meta/sentry.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "sentry",
-    "light": "sentry-light"
+    "dark": "sentry-light",
+    "light": "sentry"
   }
 }

--- a/meta/servarr.json
+++ b/meta/servarr.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "servarr",
-    "light": "servarr-light"
+    "dark": "servarr-light",
+    "light": "servarr"
   }
 }

--- a/meta/shell-tips.json
+++ b/meta/shell-tips.json
@@ -14,7 +14,7 @@
     }
   },
   "colors": {
-    "dark": "shell-tips",
-    "light": "shell-tips-light"
+    "dark": "shell-tips-light",
+    "light": "shell-tips"
   }
 }

--- a/meta/shell.json
+++ b/meta/shell.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "shell",
-    "light": "shell-light"
+    "dark": "shell-light",
+    "light": "shell"
   }
 }

--- a/meta/slash.json
+++ b/meta/slash.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "slash",
-    "light": "slash-light"
+    "dark": "slash-light",
+    "light": "slash"
   }
 }

--- a/meta/slink.json
+++ b/meta/slink.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "slink",
-    "light": "slink-light"
+    "dark": "slink-light",
+    "light": "slink"
   }
 }

--- a/meta/snappymail.json
+++ b/meta/snappymail.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "snappymail",
-    "light": "snappymail-light"
+    "dark": "snappymail-light",
+    "light": "snappymail"
   }
 }

--- a/meta/solidtime.json
+++ b/meta/solidtime.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "solidtime",
-    "light": "solidtime-light"
+    "dark": "solidtime-light",
+    "light": "solidtime"
   }
 }

--- a/meta/sonarr.json
+++ b/meta/sonarr.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "sonarr-dark",
-    "light": "sonarr"
+    "dark": "sonarr",
+    "light": "sonarr-dark"
   }
 }

--- a/meta/symmetricom.json
+++ b/meta/symmetricom.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "symmetricom",
-    "light": "symmetricom-light"
+    "dark": "symmetricom-light",
+    "light": "symmetricom"
   }
 }

--- a/meta/synapse.json
+++ b/meta/synapse.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "synapse",
-    "light": "synapse-light"
+    "dark": "synapse-light",
+    "light": "synapse"
   }
 }

--- a/meta/synclounge.json
+++ b/meta/synclounge.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "synclounge",
-    "light": "synclounge-light"
+    "dark": "synclounge-light",
+    "light": "synclounge"
   }
 }

--- a/meta/tailscale.json
+++ b/meta/tailscale.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tailscale",
-    "light": "tailscale-light"
+    "dark": "tailscale-light",
+    "light": "tailscale"
   }
 }

--- a/meta/tasmota.json
+++ b/meta/tasmota.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tasmota",
-    "light": "tasmota-light"
+    "dark": "tasmota-light",
+    "light": "tasmota"
   }
 }

--- a/meta/teamcity.json
+++ b/meta/teamcity.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "teamcity",
-    "light": "teamcity-light"
+    "dark": "teamcity-light",
+    "light": "teamcity"
   }
 }

--- a/meta/teslamate.json
+++ b/meta/teslamate.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "teslamate",
-    "light": "teslamate-light"
+    "dark": "teslamate-light",
+    "light": "teslamate"
   }
 }

--- a/meta/theia.json
+++ b/meta/theia.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "theia",
-    "light": "theia-light"
+    "dark": "theia-light",
+    "light": "theia"
   }
 }

--- a/meta/threads.json
+++ b/meta/threads.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "threads",
-    "light": "threads-light"
+    "dark": "threads-light",
+    "light": "threads"
   }
 }

--- a/meta/thunderhub.json
+++ b/meta/thunderhub.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "thunderhub",
-    "light": "thunderhub-light"
+    "dark": "thunderhub-light",
+    "light": "thunderhub"
   }
 }

--- a/meta/tianji.json
+++ b/meta/tianji.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tianji",
-    "light": "tianji-light"
+    "dark": "tianji-light",
+    "light": "tianji"
   }
 }

--- a/meta/tiddlywiki.json
+++ b/meta/tiddlywiki.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tiddlywiki",
-    "light": "tiddlywiki-light"
+    "dark": "tiddlywiki-light",
+    "light": "tiddlywiki"
   }
 }

--- a/meta/tiktok.json
+++ b/meta/tiktok.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tiktok",
-    "light": "tiktok-light"
+    "dark": "tiktok-light",
+    "light": "tiktok"
   }
 }

--- a/meta/timemachines.json
+++ b/meta/timemachines.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "timemachines",
-    "light": "timemachines-light"
+    "dark": "timemachines-light",
+    "light": "timemachines"
   }
 }

--- a/meta/timetagger.json
+++ b/meta/timetagger.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "timetagger",
-    "light": "timetagger-light"
+    "dark": "timetagger-light",
+    "light": "timetagger"
   }
 }

--- a/meta/todoist.json
+++ b/meta/todoist.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "todoist-dark",
-    "light": "todoist"
+    "dark": "todoist",
+    "light": "todoist-dark"
   }
 }

--- a/meta/tube-archivist.json
+++ b/meta/tube-archivist.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tube-archivist",
-    "light": "tube-archivist-light"
+    "dark": "tube-archivist-light",
+    "light": "tube-archivist"
   }
 }

--- a/meta/tubesync.json
+++ b/meta/tubesync.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "tubesync",
-    "light": "tubesync-light"
+    "dark": "tubesync-light",
+    "light": "tubesync"
   }
 }

--- a/meta/turbopack.json
+++ b/meta/turbopack.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "turbopack",
-    "light": "turbopack-light"
+    "dark": "turbopack-light",
+    "light": "turbopack"
   }
 }

--- a/meta/twingate.json
+++ b/meta/twingate.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "twingate",
-    "light": "twingate-light"
+    "dark": "twingate-light",
+    "light": "twingate"
   }
 }

--- a/meta/typemill.json
+++ b/meta/typemill.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "typemill",
-    "light": "typemill-light"
+    "dark": "typemill-light",
+    "light": "typemill"
   }
 }

--- a/meta/udemy.json
+++ b/meta/udemy.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "udemy",
-    "light": "udemy-light"
+    "dark": "udemy-light",
+    "light": "udemy"
   }
 }

--- a/meta/ultimate-guitar.json
+++ b/meta/ultimate-guitar.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "ultimate-guitar",
-    "light": "ultimate-guitar-light"
+    "dark": "ultimate-guitar-light",
+    "light": "ultimate-guitar"
   }
 }

--- a/meta/umami.json
+++ b/meta/umami.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "umami",
-    "light": "umami-light"
+    "dark": "umami-light",
+    "light": "umami"
   }
 }

--- a/meta/vault.json
+++ b/meta/vault.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "vault",
-    "light": "vault-light"
+    "dark": "vault-light",
+    "light": "vault"
   }
 }

--- a/meta/vaultwarden.json
+++ b/meta/vaultwarden.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "vaultwarden",
-    "light": "vaultwarden-light"
+    "dark": "vaultwarden-light",
+    "light": "vaultwarden"
   }
 }

--- a/meta/vercel.json
+++ b/meta/vercel.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "vercel",
-    "light": "vercel-light"
+    "dark": "vercel-light",
+    "light": "vercel"
   }
 }

--- a/meta/victoriametrics.json
+++ b/meta/victoriametrics.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "victoriametrics",
-    "light": "victoriametrics-light"
+    "dark": "victoriametrics-light",
+    "light": "victoriametrics"
   }
 }

--- a/meta/viseron.json
+++ b/meta/viseron.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "viseron",
-    "light": "viseron-light"
+    "dark": "viseron-light",
+    "light": "viseron"
   }
 }

--- a/meta/voltaserve.json
+++ b/meta/voltaserve.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "voltaserve",
-    "light": "voltaserve-light"
+    "dark": "voltaserve-light",
+    "light": "voltaserve"
   }
 }

--- a/meta/volumio.json
+++ b/meta/volumio.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "volumio",
-    "light": "volumio-light"
+    "dark": "volumio-light",
+    "light": "volumio"
   }
 }

--- a/meta/wakatime.json
+++ b/meta/wakatime.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "wakatime",
-    "light": "wakatime-light"
+    "dark": "wakatime-light",
+    "light": "wakatime"
   }
 }

--- a/meta/wallabag.json
+++ b/meta/wallabag.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "wallabag",
-    "light": "wallabag-light"
+    "dark": "wallabag-light",
+    "light": "wallabag"
   }
 }

--- a/meta/wanderer.json
+++ b/meta/wanderer.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "wanderer",
-    "light": "wanderer-light"
+    "dark": "wanderer-light",
+    "light": "wanderer"
   }
 }

--- a/meta/watcharr.json
+++ b/meta/watcharr.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "watcharr",
-    "light": "watcharr-light"
+    "dark": "watcharr-light",
+    "light": "watcharr"
   }
 }

--- a/meta/web-check.json
+++ b/meta/web-check.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "web-check-dark",
-    "light": "web-check"
+    "dark": "web-check",
+    "light": "web-check-dark"
   }
 }

--- a/meta/wg-gen-web.json
+++ b/meta/wg-gen-web.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "wg-gen-web",
-    "light": "wg-gen-web-light"
+    "dark": "wg-gen-web-light",
+    "light": "wg-gen-web"
   }
 }

--- a/meta/whats-up-docker.json
+++ b/meta/whats-up-docker.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "whats-up-docker",
-    "light": "whats-up-docker-light"
+    "dark": "whats-up-docker-light",
+    "light": "whats-up-docker"
   }
 }

--- a/meta/wikipedia.json
+++ b/meta/wikipedia.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "wikipedia",
-    "light": "wikipedia-light"
+    "dark": "wikipedia-light",
+    "light": "wikipedia"
   }
 }

--- a/meta/windows-95.json
+++ b/meta/windows-95.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "windows-95",
-    "light": "windows-95-light"
+    "dark": "windows-95-light",
+    "light": "windows-95"
   }
 }

--- a/meta/windows-retro.json
+++ b/meta/windows-retro.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "windows-retro",
-    "light": "windows-retro-light"
+    "dark": "windows-retro-light",
+    "light": "windows-retro"
   }
 }

--- a/meta/wolfi.json
+++ b/meta/wolfi.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "wolfi",
-    "light": "wolfi-light"
+    "dark": "wolfi-light",
+    "light": "wolfi"
   }
 }

--- a/meta/wotdle.json
+++ b/meta/wotdle.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "wotdle",
-    "light": "wotdle-light"
+    "dark": "wotdle-light",
+    "light": "wotdle"
   }
 }

--- a/meta/writefreely.json
+++ b/meta/writefreely.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "writefreely",
-    "light": "writefreely-light"
+    "dark": "writefreely-light",
+    "light": "writefreely"
   }
 }

--- a/meta/x.json
+++ b/meta/x.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "x",
-    "light": "x-light"
+    "dark": "x-light",
+    "light": "x"
   }
 }

--- a/meta/yamtrack.json
+++ b/meta/yamtrack.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "yamtrack",
-    "light": "yamtrack-light"
+    "dark": "yamtrack-light",
+    "light": "yamtrack"
   }
 }

--- a/meta/yarr.json
+++ b/meta/yarr.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "yarr",
-    "light": "yarr-light"
+    "dark": "yarr-light",
+    "light": "yarr"
   }
 }

--- a/meta/yuno-host.json
+++ b/meta/yuno-host.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "light": "yuno-host-light",
-    "dark": "yuno-host"
+    "light": "yuno-host",
+    "dark": "yuno-host-light"
   }
 }

--- a/meta/zipline.json
+++ b/meta/zipline.json
@@ -16,7 +16,7 @@
     }
   },
   "colors": {
-    "dark": "zipline",
-    "light": "zipline-light"
+    "dark": "zipline-light",
+    "light": "zipline"
   }
 }

--- a/meta/zitadel.json
+++ b/meta/zitadel.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "zitadel",
-    "light": "zitadel-light"
+    "dark": "zitadel-light",
+    "light": "zitadel"
   }
 }

--- a/meta/zyxel-communications.json
+++ b/meta/zyxel-communications.json
@@ -10,7 +10,7 @@
     }
   },
   "colors": {
-    "dark": "zyxel-communications",
-    "light": "zyxel-communications-light"
+    "dark": "zyxel-communications-light",
+    "light": "zyxel-communications"
   }
 }

--- a/meta/zyxel-networks.json
+++ b/meta/zyxel-networks.json
@@ -15,7 +15,7 @@
     }
   },
   "colors": {
-    "dark": "zyxel-networks",
-    "light": "zyxel-networks-light"
+    "dark": "zyxel-networks-light",
+    "light": "zyxel-networks"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -81,8 +81,8 @@
             }
         },
         "colors": {
-            "dark": "frigate",
-            "light": "frigate-light"
+            "dark": "frigate-light",
+            "light": "frigate"
         }
     },
     "tar1090": {
@@ -116,8 +116,8 @@
             }
         },
         "colors": {
-            "dark": "mayan-edms",
-            "light": "mayan-edms-light"
+            "dark": "mayan-edms-light",
+            "light": "mayan-edms"
         }
     },
     "php": {
@@ -269,8 +269,8 @@
             }
         },
         "colors": {
-            "dark": "invoice-ninja",
-            "light": "invoice-ninja-light"
+            "dark": "invoice-ninja-light",
+            "light": "invoice-ninja"
         }
     },
     "swarmpit": {
@@ -482,8 +482,8 @@
             }
         },
         "colors": {
-            "dark": "hollo",
-            "light": "hollo-light"
+            "dark": "hollo-light",
+            "light": "hollo"
         }
     },
     "synology-webstation": {
@@ -538,8 +538,8 @@
             }
         },
         "colors": {
-            "light": "yuno-host-light",
-            "dark": "yuno-host"
+            "light": "yuno-host",
+            "dark": "yuno-host-light"
         }
     },
     "google-assistant": {
@@ -623,8 +623,8 @@
             }
         },
         "colors": {
-            "dark": "zitadel",
-            "light": "zitadel-light"
+            "dark": "zitadel-light",
+            "light": "zitadel"
         }
     },
     "qinglong": {
@@ -658,8 +658,8 @@
             }
         },
         "colors": {
-            "dark": "android-auto-dark",
-            "light": "android-auto"
+            "dark": "android-auto",
+            "light": "android-auto-dark"
         }
     },
     "sympa": {
@@ -693,8 +693,8 @@
             }
         },
         "colors": {
-            "dark": "dub",
-            "light": "dub-light"
+            "dark": "dub-light",
+            "light": "dub"
         }
     },
     "docking-station": {
@@ -729,8 +729,8 @@
             }
         },
         "colors": {
-            "dark": "infomaniak-kdrive-dark",
-            "light": "infomaniak-kdrive-light"
+            "dark": "infomaniak-kdrive-light",
+            "light": "infomaniak-kdrive-dark"
         }
     },
     "canonical": {
@@ -767,8 +767,8 @@
             }
         },
         "colors": {
-            "dark": "backrest",
-            "light": "backrest-light"
+            "dark": "backrest-light",
+            "light": "backrest"
         }
     },
     "raneto": {
@@ -822,8 +822,8 @@
             }
         },
         "colors": {
-            "dark": "patreon",
-            "light": "patreon-light"
+            "dark": "patreon-light",
+            "light": "patreon"
         }
     },
     "embraer": {
@@ -1298,8 +1298,8 @@
             }
         },
         "colors": {
-            "dark": "pioneer",
-            "light": "pioneer-light"
+            "dark": "pioneer-light",
+            "light": "pioneer"
         }
     },
     "openpanel": {
@@ -1318,8 +1318,8 @@
             }
         },
         "colors": {
-            "dark": "openpanel",
-            "light": "openpanel-light"
+            "dark": "openpanel-light",
+            "light": "openpanel"
         }
     },
     "pingvin-share": {
@@ -1392,8 +1392,8 @@
             }
         },
         "colors": {
-            "dark": "shell-tips",
-            "light": "shell-tips-light"
+            "dark": "shell-tips-light",
+            "light": "shell-tips"
         }
     },
     "codeberg": {
@@ -1651,8 +1651,8 @@
             }
         },
         "colors": {
-            "dark": "chromecast",
-            "light": "chromecast-light"
+            "dark": "chromecast-light",
+            "light": "chromecast"
         }
     },
     "cinny": {
@@ -1672,8 +1672,8 @@
             }
         },
         "colors": {
-            "dark": "cinny",
-            "light": "cinny-light"
+            "dark": "cinny-light",
+            "light": "cinny"
         }
     },
     "openvpn": {
@@ -1729,8 +1729,8 @@
             }
         },
         "colors": {
-            "dark": "alltube",
-            "light": "alltube-light"
+            "dark": "alltube-light",
+            "light": "alltube"
         }
     },
     "homebridge": {
@@ -1819,8 +1819,8 @@
             }
         },
         "colors": {
-            "dark": "wikipedia",
-            "light": "wikipedia-light"
+            "dark": "wikipedia-light",
+            "light": "wikipedia"
         }
     },
     "gameyfin": {
@@ -1840,8 +1840,8 @@
             }
         },
         "colors": {
-            "dark": "gameyfin",
-            "light": "gameyfin-light"
+            "dark": "gameyfin-light",
+            "light": "gameyfin"
         }
     },
     "seafile": {
@@ -2098,8 +2098,8 @@
             }
         },
         "colors": {
-            "dark": "codestats",
-            "light": "codestats-light"
+            "dark": "codestats-light",
+            "light": "codestats"
         }
     },
     "microbin": {
@@ -2136,8 +2136,8 @@
             }
         },
         "colors": {
-            "dark": "plex-meta-manager",
-            "light": "plex-meta-manager-light"
+            "dark": "plex-meta-manager-light",
+            "light": "plex-meta-manager"
         }
     },
     "firefox": {
@@ -2228,8 +2228,8 @@
             }
         },
         "colors": {
-            "dark": "beaver-habit-tracker",
-            "light": "beaver-habit-tracker-light"
+            "dark": "beaver-habit-tracker-light",
+            "light": "beaver-habit-tracker"
         }
     },
     "nomie": {
@@ -2284,8 +2284,8 @@
             }
         },
         "colors": {
-            "dark": "onedev",
-            "light": "onedev-light"
+            "dark": "onedev-light",
+            "light": "onedev"
         }
     },
     "diskover": {
@@ -2476,8 +2476,8 @@
             }
         },
         "colors": {
-            "dark": "astuto",
-            "light": "astuto-light"
+            "dark": "astuto-light",
+            "light": "astuto"
         }
     },
     "zipcaptions": {
@@ -2565,8 +2565,8 @@
             }
         },
         "colors": {
-            "dark": "zyxel-networks",
-            "light": "zyxel-networks-light"
+            "dark": "zyxel-networks-light",
+            "light": "zyxel-networks"
         }
     },
     "screenconnect": {
@@ -2655,8 +2655,8 @@
             }
         },
         "colors": {
-            "dark": "dd-wrt",
-            "light": "dd-wrt-light"
+            "dark": "dd-wrt-light",
+            "light": "dd-wrt"
         }
     },
     "pfsense": {
@@ -2679,8 +2679,8 @@
             }
         },
         "colors": {
-            "dark": "pfsense",
-            "light": "pfsense-light"
+            "dark": "pfsense-light",
+            "light": "pfsense"
         }
     },
     "printer": {
@@ -2908,8 +2908,8 @@
             }
         },
         "colors": {
-            "dark": "selfh-st",
-            "light": "selfh-st-light"
+            "dark": "selfh-st-light",
+            "light": "selfh-st"
         }
     },
     "pi-alert": {
@@ -3014,8 +3014,8 @@
             }
         },
         "colors": {
-            "dark": "ami-alt",
-            "light": "ami-alt-light"
+            "dark": "ami-alt-light",
+            "light": "ami-alt"
         }
     },
     "owntracks": {
@@ -3507,8 +3507,8 @@
             }
         },
         "colors": {
-            "dark": "prime-video",
-            "light": "prime-video-light"
+            "dark": "prime-video-light",
+            "light": "prime-video"
         }
     },
     "vikunja": {
@@ -3563,8 +3563,8 @@
             }
         },
         "colors": {
-            "dark": "hemmelig",
-            "light": "hemmelig-light"
+            "dark": "hemmelig-light",
+            "light": "hemmelig"
         }
     },
     "bitwarden": {
@@ -3796,8 +3796,8 @@
             }
         },
         "colors": {
-            "dark": "passwordpusher",
-            "light": "passwordpusher-light"
+            "dark": "passwordpusher-light",
+            "light": "passwordpusher"
         }
     },
     "teslamate": {
@@ -3817,8 +3817,8 @@
             }
         },
         "colors": {
-            "dark": "teslamate",
-            "light": "teslamate-light"
+            "dark": "teslamate-light",
+            "light": "teslamate"
         }
     },
     "argo-cd": {
@@ -3856,8 +3856,8 @@
             }
         },
         "colors": {
-            "dark": "oxker",
-            "light": "oxker-light"
+            "dark": "oxker-light",
+            "light": "oxker"
         }
     },
     "goaccess": {
@@ -3878,8 +3878,8 @@
             }
         },
         "colors": {
-            "dark": "goaccess",
-            "light": "goaccess-light"
+            "dark": "goaccess-light",
+            "light": "goaccess"
         }
     },
     "obico": {
@@ -3917,8 +3917,8 @@
             }
         },
         "colors": {
-            "dark": "netbox-full-dark",
-            "light": "netbox-full"
+            "dark": "netbox-full",
+            "light": "netbox-full-dark"
         }
     },
     "duo": {
@@ -4141,8 +4141,8 @@
             }
         },
         "colors": {
-            "dark": "ultimate-guitar",
-            "light": "ultimate-guitar-light"
+            "dark": "ultimate-guitar-light",
+            "light": "ultimate-guitar"
         }
     },
     "2fauth": {
@@ -4162,8 +4162,8 @@
             }
         },
         "colors": {
-            "dark": "2fauth",
-            "light": "2fauth-light"
+            "dark": "2fauth-light",
+            "light": "2fauth"
         }
     },
     "logto": {
@@ -4302,8 +4302,8 @@
             }
         },
         "colors": {
-            "dark": "infomaniak-swisstransfer-dark",
-            "light": "infomaniak-swisstransfer-light"
+            "dark": "infomaniak-swisstransfer-light",
+            "light": "infomaniak-swisstransfer-dark"
         }
     },
     "synology": {
@@ -4395,8 +4395,8 @@
             }
         },
         "colors": {
-            "dark": "proxmox",
-            "light": "proxmox-light"
+            "dark": "proxmox-light",
+            "light": "proxmox"
         }
     },
     "wikijs-alt": {
@@ -4433,8 +4433,8 @@
             }
         },
         "colors": {
-            "dark": "ansible",
-            "light": "ansible-light"
+            "dark": "ansible-light",
+            "light": "ansible"
         }
     },
     "ferdium": {
@@ -4772,8 +4772,8 @@
             }
         },
         "colors": {
-            "dark": "locals",
-            "light": "locals-light"
+            "dark": "locals-light",
+            "light": "locals"
         }
     },
     "observo-ai": {
@@ -4915,8 +4915,8 @@
             }
         },
         "colors": {
-            "dark": "emq",
-            "light": "emq-light"
+            "dark": "emq-light",
+            "light": "emq"
         }
     },
     "rstudioserver": {
@@ -5160,8 +5160,8 @@
             }
         },
         "colors": {
-            "dark": "volumio",
-            "light": "volumio-light"
+            "dark": "volumio-light",
+            "light": "volumio"
         }
     },
     "camera-ui": {
@@ -5249,8 +5249,8 @@
             }
         },
         "colors": {
-            "dark": "greenbone",
-            "light": "greenbone-light"
+            "dark": "greenbone-light",
+            "light": "greenbone"
         }
     },
     "mariadb": {
@@ -5394,8 +5394,8 @@
             }
         },
         "colors": {
-            "dark": "fios",
-            "light": "fios-light"
+            "dark": "fios-light",
+            "light": "fios"
         }
     },
     "simplex-chat": {
@@ -5483,8 +5483,8 @@
             }
         },
         "colors": {
-            "dark": "slash",
-            "light": "slash-light"
+            "dark": "slash-light",
+            "light": "slash"
         }
     },
     "znc": {
@@ -5516,8 +5516,8 @@
             }
         },
         "colors": {
-            "dark": "plex-alt",
-            "light": "plex-alt-light"
+            "dark": "plex-alt-light",
+            "light": "plex-alt"
         }
     },
     "focalboard": {
@@ -5569,8 +5569,8 @@
             }
         },
         "colors": {
-            "light": "open-webui-light",
-            "dark": "open-webui"
+            "light": "open-webui",
+            "dark": "open-webui-light"
         }
     },
     "crater-invoice": {
@@ -6047,8 +6047,8 @@
             }
         },
         "colors": {
-            "dark": "cloud9",
-            "light": "cloud9-light"
+            "dark": "cloud9-light",
+            "light": "cloud9"
         }
     },
     "tdarr": {
@@ -6172,8 +6172,8 @@
             }
         },
         "colors": {
-            "dark": "openeats",
-            "light": "openeats-light"
+            "dark": "openeats-light",
+            "light": "openeats"
         }
     },
     "jamstack": {
@@ -6228,8 +6228,8 @@
             }
         },
         "colors": {
-            "dark": "web-check-dark",
-            "light": "web-check"
+            "dark": "web-check",
+            "light": "web-check-dark"
         }
     },
     "kerberos": {
@@ -6391,8 +6391,8 @@
             }
         },
         "colors": {
-            "dark": "posthog",
-            "light": "posthog-light"
+            "dark": "posthog-light",
+            "light": "posthog"
         }
     },
     "kook": {
@@ -6661,8 +6661,8 @@
             }
         },
         "colors": {
-            "dark": "ryot",
-            "light": "ryot-light"
+            "dark": "ryot-light",
+            "light": "ryot"
         }
     },
     "budgetbee": {
@@ -6683,8 +6683,8 @@
             }
         },
         "colors": {
-            "dark": "budgetbee",
-            "light": "budgetbee-light"
+            "dark": "budgetbee-light",
+            "light": "budgetbee"
         }
     },
     "google-wallet": {
@@ -6809,8 +6809,8 @@
             }
         },
         "colors": {
-            "dark": "rhasspy-dark",
-            "light": "rhasspy"
+            "dark": "rhasspy",
+            "light": "rhasspy-dark"
         }
     },
     "grimoire": {
@@ -6937,8 +6937,8 @@
             }
         },
         "colors": {
-            "dark": "commento",
-            "light": "commento-light"
+            "dark": "commento-light",
+            "light": "commento"
         }
     },
     "yarr": {
@@ -6958,8 +6958,8 @@
             }
         },
         "colors": {
-            "dark": "yarr",
-            "light": "yarr-light"
+            "dark": "yarr-light",
+            "light": "yarr"
         }
     },
     "windows-xp": {
@@ -7050,8 +7050,8 @@
             }
         },
         "colors": {
-            "dark": "easy-gate",
-            "light": "easy-gate-light"
+            "dark": "easy-gate-light",
+            "light": "easy-gate"
         }
     },
     "surveymonkey": {
@@ -7123,8 +7123,8 @@
             }
         },
         "colors": {
-            "dark": "turbopack",
-            "light": "turbopack-light"
+            "dark": "turbopack-light",
+            "light": "turbopack"
         }
     },
     "chrome-dev": {
@@ -7256,8 +7256,8 @@
             }
         },
         "colors": {
-            "dark": "github",
-            "light": "github-light"
+            "dark": "github-light",
+            "light": "github"
         }
     },
     "octoprint": {
@@ -7436,8 +7436,8 @@
             }
         },
         "colors": {
-            "dark": "netalertx",
-            "light": "netalertx-light"
+            "dark": "netalertx-light",
+            "light": "netalertx"
         }
     },
     "edge": {
@@ -7510,8 +7510,8 @@
             }
         },
         "colors": {
-            "dark": "midjourney",
-            "light": "midjourney-light"
+            "dark": "midjourney-light",
+            "light": "midjourney"
         }
     },
     "google-street-view": {
@@ -8016,8 +8016,8 @@
             }
         },
         "colors": {
-            "dark": "amd",
-            "light": "amd-light"
+            "dark": "amd-light",
+            "light": "amd"
         }
     },
     "rust": {
@@ -8073,8 +8073,8 @@
             }
         },
         "colors": {
-            "dark": "mikrotik",
-            "light": "mikrotik-light"
+            "dark": "mikrotik-light",
+            "light": "mikrotik"
         }
     },
     "beef": {
@@ -8093,8 +8093,8 @@
             }
         },
         "colors": {
-            "dark": "beef",
-            "light": "beef-light"
+            "dark": "beef-light",
+            "light": "beef"
         }
     },
     "musicbrainz": {
@@ -8293,8 +8293,8 @@
             }
         },
         "colors": {
-            "dark": "wallabag",
-            "light": "wallabag-light"
+            "dark": "wallabag-light",
+            "light": "wallabag"
         }
     },
     "deno": {
@@ -8315,8 +8315,8 @@
             }
         },
         "colors": {
-            "dark": "deno",
-            "light": "deno-light"
+            "dark": "deno-light",
+            "light": "deno"
         }
     },
     "youtube": {
@@ -8596,8 +8596,8 @@
             }
         },
         "colors": {
-            "dark": "grav",
-            "light": "grav-light"
+            "dark": "grav-light",
+            "light": "grav"
         }
     },
     "csharp": {
@@ -8635,8 +8635,8 @@
             }
         },
         "colors": {
-            "dark": "amazon",
-            "light": "amazon-light"
+            "dark": "amazon-light",
+            "light": "amazon"
         }
     },
     "deluge": {
@@ -8690,8 +8690,8 @@
             }
         },
         "colors": {
-            "dark": "opengist",
-            "light": "opengist-light"
+            "dark": "opengist-light",
+            "light": "opengist"
         }
     },
     "plex-rewind": {
@@ -8728,8 +8728,8 @@
             }
         },
         "colors": {
-            "dark": "booklogr",
-            "light": "booklogr-light"
+            "dark": "booklogr-light",
+            "light": "booklogr"
         }
     },
     "synology-office": {
@@ -8907,8 +8907,8 @@
             }
         },
         "colors": {
-            "dark": "guacamole",
-            "light": "guacamole-light"
+            "dark": "guacamole-light",
+            "light": "guacamole"
         }
     },
     "zammad": {
@@ -9053,8 +9053,8 @@
             }
         },
         "colors": {
-            "dark": "misskey",
-            "light": "misskey-light"
+            "dark": "misskey-light",
+            "light": "misskey"
         }
     },
     "apple-music": {
@@ -9163,8 +9163,8 @@
             }
         },
         "colors": {
-            "dark": "double-take-dark",
-            "light": "double-take"
+            "dark": "double-take",
+            "light": "double-take-dark"
         }
     },
     "mediathekview": {
@@ -9237,8 +9237,8 @@
             }
         },
         "colors": {
-            "dark": "miniflux",
-            "light": "miniflux-light"
+            "dark": "miniflux-light",
+            "light": "miniflux"
         }
     },
     "papermerge": {
@@ -9259,8 +9259,8 @@
             }
         },
         "colors": {
-            "dark": "papermerge",
-            "light": "papermerge-light"
+            "dark": "papermerge-light",
+            "light": "papermerge"
         }
     },
     "zipline": {
@@ -9281,8 +9281,8 @@
             }
         },
         "colors": {
-            "dark": "zipline",
-            "light": "zipline-light"
+            "dark": "zipline-light",
+            "light": "zipline"
         }
     },
     "lidarr": {
@@ -9532,8 +9532,8 @@
             }
         },
         "colors": {
-            "dark": "openai",
-            "light": "openai-light"
+            "dark": "openai-light",
+            "light": "openai"
         }
     },
     "microsoft-excel": {
@@ -9660,8 +9660,8 @@
             }
         },
         "colors": {
-            "dark": "funkwhale",
-            "light": "funkwhale-light"
+            "dark": "funkwhale-light",
+            "light": "funkwhale"
         }
     },
     "gerbera": {
@@ -9734,8 +9734,8 @@
             }
         },
         "colors": {
-            "dark": "moodist-dark",
-            "light": "moodist"
+            "dark": "moodist",
+            "light": "moodist-dark"
         }
     },
     "rsshub": {
@@ -9774,8 +9774,8 @@
             }
         },
         "colors": {
-            "dark": "snappymail",
-            "light": "snappymail-light"
+            "dark": "snappymail-light",
+            "light": "snappymail"
         }
     },
     "overleaf": {
@@ -9847,8 +9847,8 @@
             }
         },
         "colors": {
-            "dark": "hatsh",
-            "light": "hatsh-light"
+            "dark": "hatsh-light",
+            "light": "hatsh"
         }
     },
     "tux": {
@@ -9903,8 +9903,8 @@
             }
         },
         "colors": {
-            "dark": "shell",
-            "light": "shell-light"
+            "dark": "shell-light",
+            "light": "shell"
         }
     },
     "cloudflare-zero-trust": {
@@ -10048,8 +10048,8 @@
             }
         },
         "colors": {
-            "dark": "apple-tv-plus",
-            "light": "apple-tv-plus-light"
+            "dark": "apple-tv-plus-light",
+            "light": "apple-tv-plus"
         }
     },
     "channels-dvr": {
@@ -10424,8 +10424,8 @@
             }
         },
         "colors": {
-            "dark": "revolt",
-            "light": "revolt-light"
+            "dark": "revolt-light",
+            "light": "revolt"
         }
     },
     "phanpy": {
@@ -10530,8 +10530,8 @@
             }
         },
         "colors": {
-            "dark": "umami",
-            "light": "umami-light"
+            "dark": "umami-light",
+            "light": "umami"
         }
     },
     "multi-scrobbler": {
@@ -10568,8 +10568,8 @@
             }
         },
         "colors": {
-            "dark": "udemy",
-            "light": "udemy-light"
+            "dark": "udemy-light",
+            "light": "udemy"
         }
     },
     "updog": {
@@ -10625,8 +10625,8 @@
             }
         },
         "colors": {
-            "dark": "converse",
-            "light": "converse-light"
+            "dark": "converse-light",
+            "light": "converse"
         }
     },
     "davical": {
@@ -10923,8 +10923,8 @@
             }
         },
         "colors": {
-            "dark": "windows-retro",
-            "light": "windows-retro-light"
+            "dark": "windows-retro-light",
+            "light": "windows-retro"
         }
     },
     "brewpi": {
@@ -10962,8 +10962,8 @@
             }
         },
         "colors": {
-            "dark": "wakatime",
-            "light": "wakatime-light"
+            "dark": "wakatime-light",
+            "light": "wakatime"
         }
     },
     "mysql": {
@@ -11076,8 +11076,8 @@
             }
         },
         "colors": {
-            "dark": "readthedocs",
-            "light": "readthedocs-light"
+            "dark": "readthedocs-light",
+            "light": "readthedocs"
         }
     },
     "invoiceninja": {
@@ -11092,8 +11092,8 @@
             }
         },
         "colors": {
-            "dark": "invoiceninja",
-            "light": "invoiceninja-light"
+            "dark": "invoiceninja-light",
+            "light": "invoiceninja"
         }
     },
     "kinto": {
@@ -11228,8 +11228,8 @@
             }
         },
         "colors": {
-            "dark": "glance",
-            "light": "glance-light"
+            "dark": "glance-light",
+            "light": "glance"
         }
     },
     "postgresql": {
@@ -11368,8 +11368,8 @@
             }
         },
         "colors": {
-            "dark": "devtooly",
-            "light": "devtooly-light"
+            "dark": "devtooly-light",
+            "light": "devtooly"
         }
     },
     "changedetection": {
@@ -11408,8 +11408,8 @@
             }
         },
         "colors": {
-            "dark": "todoist-dark",
-            "light": "todoist"
+            "dark": "todoist",
+            "light": "todoist-dark"
         }
     },
     "tolgee": {
@@ -11526,8 +11526,8 @@
             }
         },
         "colors": {
-            "dark": "timemachines",
-            "light": "timemachines-light"
+            "dark": "timemachines-light",
+            "light": "timemachines"
         }
     },
     "handbrake": {
@@ -11554,8 +11554,8 @@
             }
         },
         "colors": {
-            "dark": "olivetin",
-            "light": "olivetin-light"
+            "dark": "olivetin-light",
+            "light": "olivetin"
         }
     },
     "pushover": {
@@ -11632,8 +11632,8 @@
             }
         },
         "colors": {
-            "dark": "icinga",
-            "light": "icinga-light"
+            "dark": "icinga-light",
+            "light": "icinga"
         }
     },
     "endless": {
@@ -11648,8 +11648,8 @@
             }
         },
         "colors": {
-            "dark": "endless",
-            "light": "endless-light"
+            "dark": "endless-light",
+            "light": "endless"
         }
     },
     "teamspeak": {
@@ -11700,8 +11700,8 @@
             }
         },
         "colors": {
-            "dark": "netbox-dark",
-            "light": "netbox"
+            "dark": "netbox",
+            "light": "netbox-dark"
         }
     },
     "quetre": {
@@ -11812,8 +11812,8 @@
             }
         },
         "colors": {
-            "dark": "rimgo",
-            "light": "rimgo-light"
+            "dark": "rimgo-light",
+            "light": "rimgo"
         }
     },
     "ara-records-ansible": {
@@ -11876,8 +11876,8 @@
             }
         },
         "colors": {
-            "dark": "watcharr",
-            "light": "watcharr-light"
+            "dark": "watcharr-light",
+            "light": "watcharr"
         }
     },
     "lastpass": {
@@ -11930,8 +11930,8 @@
             }
         },
         "colors": {
-            "dark": "pwpush",
-            "light": "pwpush-light"
+            "dark": "pwpush-light",
+            "light": "pwpush"
         }
     },
     "webtorrent": {
@@ -12108,8 +12108,8 @@
             }
         },
         "colors": {
-            "dark": "docassemble",
-            "light": "docassemble-light"
+            "dark": "docassemble-light",
+            "light": "docassemble"
         }
     },
     "haproxy": {
@@ -12136,8 +12136,8 @@
             }
         },
         "colors": {
-            "dark": "nightscout",
-            "light": "nightscout-light"
+            "dark": "nightscout-light",
+            "light": "nightscout"
         }
     },
     "hashicorp-packer": {
@@ -12284,8 +12284,8 @@
             }
         },
         "colors": {
-            "dark": "raspberry-pi",
-            "light": "raspberry-pi-light"
+            "dark": "raspberry-pi-light",
+            "light": "raspberry-pi"
         }
     },
     "docsify": {
@@ -12396,8 +12396,8 @@
             }
         },
         "colors": {
-            "dark": "lancommander",
-            "light": "lancommander-light"
+            "dark": "lancommander-light",
+            "light": "lancommander"
         }
     },
     "roundcube": {
@@ -12424,8 +12424,8 @@
             }
         },
         "colors": {
-            "dark": "phoneinfoga",
-            "light": "phoneinfoga-light"
+            "dark": "phoneinfoga-light",
+            "light": "phoneinfoga"
         }
     },
     "yahoo-mail": {
@@ -12512,8 +12512,8 @@
             }
         },
         "colors": {
-            "dark": "papermark",
-            "light": "papermark-light"
+            "dark": "papermark-light",
+            "light": "papermark"
         }
     },
     "chatgpt": {
@@ -12636,8 +12636,8 @@
             }
         },
         "colors": {
-            "dark": "wotdle",
-            "light": "wotdle-light"
+            "dark": "wotdle-light",
+            "light": "wotdle"
         }
     },
     "dell": {
@@ -12772,8 +12772,8 @@
             }
         },
         "colors": {
-            "dark": "cockpit",
-            "light": "cockpit-light"
+            "dark": "cockpit-light",
+            "light": "cockpit"
         }
     },
     "nextcloud-tasks": {
@@ -12888,8 +12888,8 @@
             }
         },
         "colors": {
-            "light": "karakeep",
-            "dark": "karakeep-dark"
+            "light": "karakeep-dark",
+            "dark": "karakeep"
         }
     },
     "upsnap": {
@@ -13004,8 +13004,8 @@
             }
         },
         "colors": {
-            "dark": "it-tools",
-            "light": "it-tools-light"
+            "dark": "it-tools-light",
+            "light": "it-tools"
         }
     },
     "scanservjs": {
@@ -13274,8 +13274,8 @@
             }
         },
         "colors": {
-            "dark": "viseron",
-            "light": "viseron-light"
+            "dark": "viseron-light",
+            "light": "viseron"
         }
     },
     "jetkvm-full": {
@@ -13302,8 +13302,8 @@
             }
         },
         "colors": {
-            "dark": "sonarr-dark",
-            "light": "sonarr"
+            "dark": "sonarr",
+            "light": "sonarr-dark"
         }
     },
     "cpanel": {
@@ -13354,8 +13354,8 @@
             }
         },
         "colors": {
-            "dark": "enclosed",
-            "light": "enclosed-light"
+            "dark": "enclosed-light",
+            "light": "enclosed"
         }
     },
     "rclone": {
@@ -13394,8 +13394,8 @@
             }
         },
         "colors": {
-            "dark": "infomaniak-kmeet-dark",
-            "light": "infomaniak-kmeet-light"
+            "dark": "infomaniak-kmeet-light",
+            "light": "infomaniak-kmeet-dark"
         }
     },
     "azure-container-service": {
@@ -13470,8 +13470,8 @@
             }
         },
         "colors": {
-            "dark": "selfhosted",
-            "light": "selfhosted-light"
+            "dark": "selfhosted-light",
+            "light": "selfhosted"
         }
     },
     "fladder": {
@@ -13526,8 +13526,8 @@
             }
         },
         "colors": {
-            "dark": "eleventy",
-            "light": "eleventy-light"
+            "dark": "eleventy-light",
+            "light": "eleventy"
         }
     },
     "linkwarden": {
@@ -13674,8 +13674,8 @@
             }
         },
         "colors": {
-            "dark": "oculus",
-            "light": "oculus-light"
+            "dark": "oculus-light",
+            "light": "oculus"
         }
     },
     "cloudstream": {
@@ -13704,8 +13704,8 @@
             }
         },
         "colors": {
-            "dark": "odysee-full-dark",
-            "light": "odysee-full-light"
+            "dark": "odysee-full-light",
+            "light": "odysee-full-dark"
         }
     },
     "piped": {
@@ -13756,8 +13756,8 @@
             }
         },
         "colors": {
-            "dark": "meshping",
-            "light": "meshping-light"
+            "dark": "meshping-light",
+            "light": "meshping"
         }
     },
     "nxlog": {
@@ -13870,8 +13870,8 @@
             }
         },
         "colors": {
-            "dark": "openchangelog",
-            "light": "openchangelog-light"
+            "dark": "openchangelog-light",
+            "light": "openchangelog"
         }
     },
     "libreddit": {
@@ -13886,8 +13886,8 @@
             }
         },
         "colors": {
-            "dark": "libreddit",
-            "light": "libreddit-light"
+            "dark": "libreddit-light",
+            "light": "libreddit"
         }
     },
     "google-compute-engine": {
@@ -13992,8 +13992,8 @@
             }
         },
         "colors": {
-            "dark": "nextjs",
-            "light": "nextjs-light"
+            "dark": "nextjs-light",
+            "light": "nextjs"
         }
     },
     "triliumnext": {
@@ -14044,8 +14044,8 @@
             }
         },
         "colors": {
-            "dark": "symmetricom",
-            "light": "symmetricom-light"
+            "dark": "symmetricom-light",
+            "light": "symmetricom"
         }
     },
     "google-tv": {
@@ -14274,8 +14274,8 @@
             }
         },
         "colors": {
-            "dark": "synclounge",
-            "light": "synclounge-light"
+            "dark": "synclounge-light",
+            "light": "synclounge"
         }
     },
     "shellngn": {
@@ -14378,8 +14378,8 @@
             }
         },
         "colors": {
-            "dark": "1password-dark",
-            "light": "1password"
+            "dark": "1password",
+            "light": "1password-dark"
         }
     },
     "browsh": {
@@ -14482,8 +14482,8 @@
             }
         },
         "colors": {
-            "dark": "feedlynx",
-            "light": "feedlynx-light"
+            "dark": "feedlynx-light",
+            "light": "feedlynx"
         }
     },
     "truenas-core": {
@@ -14522,8 +14522,8 @@
             }
         },
         "colors": {
-            "dark": "cal-com",
-            "light": "cal-com-light"
+            "dark": "cal-com-light",
+            "light": "cal-com"
         }
     },
     "wger": {
@@ -14610,8 +14610,8 @@
             }
         },
         "colors": {
-            "dark": "immich-frame",
-            "light": "immich-frame-light"
+            "dark": "immich-frame-light",
+            "light": "immich-frame"
         }
     },
     "plexripper": {
@@ -14638,8 +14638,8 @@
             }
         },
         "colors": {
-            "dark": "wg-gen-web",
-            "light": "wg-gen-web-light"
+            "dark": "wg-gen-web-light",
+            "light": "wg-gen-web"
         }
     },
     "microsoft-office": {
@@ -14681,8 +14681,8 @@
             }
         },
         "colors": {
-            "dark": "i2p",
-            "light": "i2p-light"
+            "dark": "i2p-light",
+            "light": "i2p"
         }
     },
     "bitbucket": {
@@ -14745,8 +14745,8 @@
             }
         },
         "colors": {
-            "dark": "cockpit-cms",
-            "light": "cockpit-cms-light"
+            "dark": "cockpit-cms-light",
+            "light": "cockpit-cms"
         }
     },
     "ferdi": {
@@ -14857,8 +14857,8 @@
             }
         },
         "colors": {
-            "dark": "timetagger",
-            "light": "timetagger-light"
+            "dark": "timetagger-light",
+            "light": "timetagger"
         }
     },
     "whats-up-docker": {
@@ -14873,8 +14873,8 @@
             }
         },
         "colors": {
-            "dark": "whats-up-docker",
-            "light": "whats-up-docker-light"
+            "dark": "whats-up-docker-light",
+            "light": "whats-up-docker"
         }
     },
     "youtube-dl": {
@@ -15121,8 +15121,8 @@
             }
         },
         "colors": {
-            "dark": "twingate",
-            "light": "twingate-light"
+            "dark": "twingate-light",
+            "light": "twingate"
         }
     },
     "fermentrack": {
@@ -15149,8 +15149,8 @@
             }
         },
         "colors": {
-            "dark": "monica",
-            "light": "monica-light"
+            "dark": "monica-light",
+            "light": "monica"
         }
     },
     "auracast": {
@@ -15409,8 +15409,8 @@
             }
         },
         "colors": {
-            "dark": "pdfding",
-            "light": "pdfding-light"
+            "dark": "pdfding-light",
+            "light": "pdfding"
         }
     },
     "ddclient": {
@@ -15437,8 +15437,8 @@
             }
         },
         "colors": {
-            "dark": "navidrome",
-            "light": "navidrome-light"
+            "dark": "navidrome-light",
+            "light": "navidrome"
         }
     },
     "jellystat": {
@@ -15801,8 +15801,8 @@
             }
         },
         "colors": {
-            "dark": "photonix",
-            "light": "photonix-light"
+            "dark": "photonix-light",
+            "light": "photonix"
         }
     },
     "ezbookkeeping": {
@@ -15989,8 +15989,8 @@
             }
         },
         "colors": {
-            "dark": "nocobase",
-            "light": "nocobase-light"
+            "dark": "nocobase-light",
+            "light": "nocobase"
         }
     },
     "microsoft-365": {
@@ -16017,8 +16017,8 @@
             }
         },
         "colors": {
-            "dark": "pastatool",
-            "light": "pastatool-light"
+            "dark": "pastatool-light",
+            "light": "pastatool"
         }
     },
     "apache-solr": {
@@ -16061,8 +16061,8 @@
             }
         },
         "colors": {
-            "dark": "html",
-            "light": "html-light"
+            "dark": "html-light",
+            "light": "html"
         }
     },
     "whisparr": {
@@ -16101,8 +16101,8 @@
             }
         },
         "colors": {
-            "dark": "hbo",
-            "light": "hbo-light"
+            "dark": "hbo-light",
+            "light": "hbo"
         }
     },
     "epic-games": {
@@ -16117,8 +16117,8 @@
             }
         },
         "colors": {
-            "dark": "epic-games",
-            "light": "epic-games-light"
+            "dark": "epic-games-light",
+            "light": "epic-games"
         }
     },
     "runonflux": {
@@ -16245,8 +16245,8 @@
             }
         },
         "colors": {
-            "dark": "lyrion-dark",
-            "light": "lyrion"
+            "dark": "lyrion",
+            "light": "lyrion-dark"
         }
     },
     "cc": {
@@ -16261,8 +16261,8 @@
             }
         },
         "colors": {
-            "dark": "cc",
-            "light": "cc-light"
+            "dark": "cc-light",
+            "light": "cc"
         }
     },
     "tvdb": {
@@ -16289,8 +16289,8 @@
             }
         },
         "colors": {
-            "dark": "feedbin",
-            "light": "feedbin-light"
+            "dark": "feedbin-light",
+            "light": "feedbin"
         }
     },
     "avm-fritzbox": {
@@ -16345,8 +16345,8 @@
             }
         },
         "colors": {
-            "dark": "flightradar24",
-            "light": "flightradar24-light"
+            "dark": "flightradar24-light",
+            "light": "flightradar24"
         }
     },
     "foldingathome": {
@@ -16373,8 +16373,8 @@
             }
         },
         "colors": {
-            "dark": "oscarr",
-            "light": "oscarr-light"
+            "dark": "oscarr-light",
+            "light": "oscarr"
         }
     },
     "alertmanager": {
@@ -16437,8 +16437,8 @@
             }
         },
         "colors": {
-            "dark": "vercel",
-            "light": "vercel-light"
+            "dark": "vercel-light",
+            "light": "vercel"
         }
     },
     "alma-linux": {
@@ -16465,8 +16465,8 @@
             }
         },
         "colors": {
-            "dark": "apache-tomcat",
-            "light": "apache-tomcat-light"
+            "dark": "apache-tomcat-light",
+            "light": "apache-tomcat"
         }
     },
     "petio": {
@@ -16541,8 +16541,8 @@
             }
         },
         "colors": {
-            "light": "pikvm-light",
-            "dark": "pikvm"
+            "light": "pikvm",
+            "dark": "pikvm-light"
         }
     },
     "ubiquiti-unifi": {
@@ -16569,8 +16569,8 @@
             }
         },
         "colors": {
-            "dark": "docker-mailserver",
-            "light": "docker-mailserver-light"
+            "dark": "docker-mailserver-light",
+            "light": "docker-mailserver"
         }
     },
     "artifacthub": {
@@ -16597,8 +16597,8 @@
             }
         },
         "colors": {
-            "dark": "redlib",
-            "light": "redlib-light"
+            "dark": "redlib-light",
+            "light": "redlib"
         }
     },
     "telekom": {
@@ -16625,8 +16625,8 @@
             }
         },
         "colors": {
-            "dark": "runson",
-            "light": "runson-light"
+            "dark": "runson-light",
+            "light": "runson"
         }
     },
     "kasm-workspaces": {
@@ -16653,8 +16653,8 @@
             }
         },
         "colors": {
-            "dark": "writefreely",
-            "light": "writefreely-light"
+            "dark": "writefreely-light",
+            "light": "writefreely"
         }
     },
     "tenda": {
@@ -16809,8 +16809,8 @@
             }
         },
         "colors": {
-            "dark": "esphome",
-            "light": "esphome-light"
+            "dark": "esphome-light",
+            "light": "esphome"
         }
     },
     "docuseal": {
@@ -16837,8 +16837,8 @@
             }
         },
         "colors": {
-            "dark": "tianji",
-            "light": "tianji-light"
+            "dark": "tianji-light",
+            "light": "tianji"
         }
     },
     "google-finance": {
@@ -16951,8 +16951,8 @@
             }
         },
         "colors": {
-            "dark": "moodle",
-            "light": "moodle-light"
+            "dark": "moodle-light",
+            "light": "moodle"
         }
     },
     "kapacitor": {
@@ -17003,8 +17003,8 @@
             }
         },
         "colors": {
-            "dark": "sabnzbd",
-            "light": "sabnzbd-light"
+            "dark": "sabnzbd-light",
+            "light": "sabnzbd"
         }
     },
     "homey": {
@@ -17163,8 +17163,8 @@
             }
         },
         "colors": {
-            "dark": "threads",
-            "light": "threads-light"
+            "dark": "threads-light",
+            "light": "threads"
         }
     },
     "netlify": {
@@ -17203,8 +17203,8 @@
             }
         },
         "colors": {
-            "dark": "lynx",
-            "light": "lynx-light"
+            "dark": "lynx-light",
+            "light": "lynx"
         }
     },
     "peanut": {
@@ -17219,8 +17219,8 @@
             }
         },
         "colors": {
-            "dark": "peanut",
-            "light": "peanut-light"
+            "dark": "peanut-light",
+            "light": "peanut"
         }
     },
     "wanikani": {
@@ -17287,8 +17287,8 @@
             }
         },
         "colors": {
-            "dark": "wanderer",
-            "light": "wanderer-light"
+            "dark": "wanderer-light",
+            "light": "wanderer"
         }
     },
     "docker-amvd": {
@@ -17439,8 +17439,8 @@
             }
         },
         "colors": {
-            "dark": "minio",
-            "light": "minio-light"
+            "dark": "minio-light",
+            "light": "minio"
         }
     },
     "grocy": {
@@ -17599,8 +17599,8 @@
             }
         },
         "colors": {
-            "dark": "secureai-tools",
-            "light": "secureai-tools-light"
+            "dark": "secureai-tools-light",
+            "light": "secureai-tools"
         }
     },
     "kodi": {
@@ -17723,8 +17723,8 @@
             }
         },
         "colors": {
-            "dark": "penpot",
-            "light": "penpot-light"
+            "dark": "penpot-light",
+            "light": "penpot"
         }
     },
     "blogger": {
@@ -17775,8 +17775,8 @@
             }
         },
         "colors": {
-            "dark": "cardigann",
-            "light": "cardigann-light"
+            "dark": "cardigann-light",
+            "light": "cardigann"
         }
     },
     "confluence": {
@@ -17827,8 +17827,8 @@
             }
         },
         "colors": {
-            "dark": "edgeos",
-            "light": "edgeos-light"
+            "dark": "edgeos-light",
+            "light": "edgeos"
         }
     },
     "sentry": {
@@ -17843,8 +17843,8 @@
             }
         },
         "colors": {
-            "dark": "sentry",
-            "light": "sentry-light"
+            "dark": "sentry-light",
+            "light": "sentry"
         }
     },
     "digital-ocean": {
@@ -17871,8 +17871,8 @@
             }
         },
         "colors": {
-            "dark": "homebox",
-            "light": "homebox-light"
+            "dark": "homebox-light",
+            "light": "homebox"
         }
     },
     "windows-7": {
@@ -18023,8 +18023,8 @@
             }
         },
         "colors": {
-            "dark": "picsur",
-            "light": "picsur-light"
+            "dark": "picsur-light",
+            "light": "picsur"
         }
     },
     "appflowy": {
@@ -18079,8 +18079,8 @@
             }
         },
         "colors": {
-            "dark": "raritan",
-            "light": "raritan-light"
+            "dark": "raritan-light",
+            "light": "raritan"
         }
     },
     "directadmin": {
@@ -18179,8 +18179,8 @@
             }
         },
         "colors": {
-            "dark": "browserless",
-            "light": "browserless-light"
+            "dark": "browserless-light",
+            "light": "browserless"
         }
     },
     "hashicorp-boundary": {
@@ -18423,8 +18423,8 @@
             }
         },
         "colors": {
-            "dark": "phoscon",
-            "light": "phoscon-light"
+            "dark": "phoscon-light",
+            "light": "phoscon"
         }
     },
     "wakapi": {
@@ -18451,8 +18451,8 @@
             }
         },
         "colors": {
-            "dark": "slink",
-            "light": "slink-light"
+            "dark": "slink-light",
+            "light": "slink"
         }
     },
     "listmonk": {
@@ -18611,8 +18611,8 @@
             }
         },
         "colors": {
-            "dark": "anything-llm",
-            "light": "anything-llm-light"
+            "dark": "anything-llm-light",
+            "light": "anything-llm"
         }
     },
     "heimdall": {
@@ -18627,8 +18627,8 @@
             }
         },
         "colors": {
-            "dark": "heimdall",
-            "light": "heimdall-light"
+            "dark": "heimdall-light",
+            "light": "heimdall"
         }
     },
     "z-wave-js-ui": {
@@ -18679,8 +18679,8 @@
             }
         },
         "colors": {
-            "dark": "tiktok",
-            "light": "tiktok-light"
+            "dark": "tiktok-light",
+            "light": "tiktok"
         }
     },
     "5etools": {
@@ -18795,8 +18795,8 @@
             }
         },
         "colors": {
-            "dark": "notesnook",
-            "light": "notesnook-light"
+            "dark": "notesnook-light",
+            "light": "notesnook"
         }
     },
     "racknerd": {
@@ -18999,8 +18999,8 @@
             }
         },
         "colors": {
-            "dark": "tailscale",
-            "light": "tailscale-light"
+            "dark": "tailscale-light",
+            "light": "tailscale"
         }
     },
     "elastic-beats": {
@@ -19027,8 +19027,8 @@
             }
         },
         "colors": {
-            "dark": "medusa",
-            "light": "medusa-light"
+            "dark": "medusa-light",
+            "light": "medusa"
         }
     },
     "readarr": {
@@ -19091,8 +19091,8 @@
             }
         },
         "colors": {
-            "dark": "memories",
-            "light": "memories-light"
+            "dark": "memories-light",
+            "light": "memories"
         }
     },
     "fontawesome": {
@@ -19227,8 +19227,8 @@
             }
         },
         "colors": {
-            "dark": "glances",
-            "light": "glances-light"
+            "dark": "glances-light",
+            "light": "glances"
         }
     },
     "nextcloud-social": {
@@ -19279,8 +19279,8 @@
             }
         },
         "colors": {
-            "dark": "notion",
-            "light": "notion-light"
+            "dark": "notion-light",
+            "light": "notion"
         }
     },
     "pyload": {
@@ -19433,8 +19433,8 @@
             }
         },
         "colors": {
-            "dark": "archiveteam-warrior",
-            "light": "archiveteam-warrior-light"
+            "dark": "archiveteam-warrior-light",
+            "light": "archiveteam-warrior"
         }
     },
     "aws-ecs": {
@@ -19549,8 +19549,8 @@
             }
         },
         "colors": {
-            "dark": "atuin",
-            "light": "atuin-light"
+            "dark": "atuin-light",
+            "light": "atuin"
         }
     },
     "dillinger": {
@@ -19565,8 +19565,8 @@
             }
         },
         "colors": {
-            "dark": "dillinger",
-            "light": "dillinger-light"
+            "dark": "dillinger-light",
+            "light": "dillinger"
         }
     },
     "sonarqube": {
@@ -19749,8 +19749,8 @@
             }
         },
         "colors": {
-            "dark": "zyxel-communications",
-            "light": "zyxel-communications-light"
+            "dark": "zyxel-communications-light",
+            "light": "zyxel-communications"
         }
     },
     "rport": {
@@ -19897,8 +19897,8 @@
             }
         },
         "colors": {
-            "dark": "tubesync",
-            "light": "tubesync-light"
+            "dark": "tubesync-light",
+            "light": "tubesync"
         }
     },
     "homepage": {
@@ -19973,8 +19973,8 @@
             }
         },
         "colors": {
-            "dark": "mailchimp",
-            "light": "mailchimp-light"
+            "dark": "mailchimp-light",
+            "light": "mailchimp"
         }
     },
     "sickgear": {
@@ -20001,8 +20001,8 @@
             }
         },
         "colors": {
-            "dark": "3cx",
-            "light": "3cx-light"
+            "dark": "3cx-light",
+            "light": "3cx"
         }
     },
     "matomo": {
@@ -20077,8 +20077,8 @@
             }
         },
         "colors": {
-            "dark": "thunderhub",
-            "light": "thunderhub-light"
+            "dark": "thunderhub-light",
+            "light": "thunderhub"
         }
     },
     "alpine-linux": {
@@ -20189,8 +20189,8 @@
             }
         },
         "colors": {
-            "dark": "planka-dark",
-            "light": "planka"
+            "dark": "planka",
+            "light": "planka-dark"
         }
     },
     "kanidm": {
@@ -20217,8 +20217,8 @@
             }
         },
         "colors": {
-            "dark": "akkoma",
-            "light": "akkoma-light"
+            "dark": "akkoma-light",
+            "light": "akkoma"
         }
     },
     "grist": {
@@ -20245,8 +20245,8 @@
             }
         },
         "colors": {
-            "dark": "neko",
-            "light": "neko-light"
+            "dark": "neko-light",
+            "light": "neko"
         }
     },
     "python": {
@@ -20325,8 +20325,8 @@
             }
         },
         "colors": {
-            "dark": "pocket-id",
-            "light": "pocket-id-light"
+            "dark": "pocket-id-light",
+            "light": "pocket-id"
         }
     },
     "kick": {
@@ -20341,8 +20341,8 @@
             }
         },
         "colors": {
-            "dark": "kick",
-            "light": "kick-light"
+            "dark": "kick-light",
+            "light": "kick"
         }
     },
     "css": {
@@ -20357,8 +20357,8 @@
             }
         },
         "colors": {
-            "dark": "css",
-            "light": "css-light"
+            "dark": "css-light",
+            "light": "css"
         }
     },
     "unifi-controller": {
@@ -20385,8 +20385,8 @@
             }
         },
         "colors": {
-            "dark": "tasmota",
-            "light": "tasmota-light"
+            "dark": "tasmota-light",
+            "light": "tasmota"
         }
     },
     "metabase": {
@@ -20501,8 +20501,8 @@
             }
         },
         "colors": {
-            "dark": "ovirt",
-            "light": "ovirt-light"
+            "dark": "ovirt-light",
+            "light": "ovirt"
         }
     },
     "syncthing": {
@@ -20655,8 +20655,8 @@
             }
         },
         "colors": {
-            "dark": "hammond",
-            "light": "hammond-light"
+            "dark": "hammond-light",
+            "light": "hammond"
         }
     },
     "collabora-online": {
@@ -20771,8 +20771,8 @@
             }
         },
         "colors": {
-            "dark": "dim",
-            "light": "dim-light"
+            "dark": "dim-light",
+            "light": "dim"
         }
     },
     "mojeek": {
@@ -20823,8 +20823,8 @@
             }
         },
         "colors": {
-            "dark": "broadcastchannel",
-            "light": "broadcastchannel-light"
+            "dark": "broadcastchannel-light",
+            "light": "broadcastchannel"
         }
     },
     "snapcast": {
@@ -20937,8 +20937,8 @@
             }
         },
         "colors": {
-            "dark": "plex",
-            "light": "plex-light"
+            "dark": "plex-light",
+            "light": "plex"
         }
     },
     "hyperpipe": {
@@ -20953,8 +20953,8 @@
             }
         },
         "colors": {
-            "dark": "hyperpipe",
-            "light": "hyperpipe-light"
+            "dark": "hyperpipe-light",
+            "light": "hyperpipe"
         }
     },
     "donetick": {
@@ -20981,8 +20981,8 @@
             }
         },
         "colors": {
-            "dark": "feedbase",
-            "light": "feedbase-light"
+            "dark": "feedbase-light",
+            "light": "feedbase"
         }
     },
     "fedora-alt": {
@@ -21045,8 +21045,8 @@
             }
         },
         "colors": {
-            "dark": "peacock",
-            "light": "peacock-light"
+            "dark": "peacock-light",
+            "light": "peacock"
         }
     },
     "kiwix": {
@@ -21061,8 +21061,8 @@
             }
         },
         "colors": {
-            "dark": "kiwix",
-            "light": "kiwix-light"
+            "dark": "kiwix-light",
+            "light": "kiwix"
         }
     },
     "casaos": {
@@ -21185,8 +21185,8 @@
             }
         },
         "colors": {
-            "dark": "vault",
-            "light": "vault-light"
+            "dark": "vault-light",
+            "light": "vault"
         }
     },
     "clash": {
@@ -21225,8 +21225,8 @@
             }
         },
         "colors": {
-            "dark": "denon",
-            "light": "denon-light"
+            "dark": "denon-light",
+            "light": "denon"
         }
     },
     "zendesk": {
@@ -21277,8 +21277,8 @@
             }
         },
         "colors": {
-            "dark": "x",
-            "light": "x-light"
+            "dark": "x-light",
+            "light": "x"
         }
     },
     "yacd-blue": {
@@ -21357,8 +21357,8 @@
             }
         },
         "colors": {
-            "dark": "voltaserve",
-            "light": "voltaserve-light"
+            "dark": "voltaserve-light",
+            "light": "voltaserve"
         }
     },
     "terraform": {
@@ -21457,8 +21457,8 @@
             }
         },
         "colors": {
-            "dark": "hoarder",
-            "light": "hoarder-light"
+            "dark": "hoarder-light",
+            "light": "hoarder"
         }
     },
     "google-messages": {
@@ -21485,8 +21485,8 @@
             }
         },
         "colors": {
-            "dark": "theia",
-            "light": "theia-light"
+            "dark": "theia-light",
+            "light": "theia"
         }
     },
     "linuxgsm": {
@@ -21549,8 +21549,8 @@
             }
         },
         "colors": {
-            "dark": "podfetch",
-            "light": "podfetch-light"
+            "dark": "podfetch-light",
+            "light": "podfetch"
         }
     },
     "ntop": {
@@ -21577,8 +21577,8 @@
             }
         },
         "colors": {
-            "dark": "kanboard",
-            "light": "kanboard-light"
+            "dark": "kanboard-light",
+            "light": "kanboard"
         }
     },
     "flarum": {
@@ -21653,8 +21653,8 @@
             }
         },
         "colors": {
-            "dark": "ghost",
-            "light": "ghost-light"
+            "dark": "ghost-light",
+            "light": "ghost"
         }
     },
     "gonic": {
@@ -21693,8 +21693,8 @@
             }
         },
         "colors": {
-            "dark": "fast-com",
-            "light": "fast-com-light"
+            "dark": "fast-com-light",
+            "light": "fast-com"
         }
     },
     "soulseek": {
@@ -21833,8 +21833,8 @@
             }
         },
         "colors": {
-            "dark": "ownphotos",
-            "light": "ownphotos-light"
+            "dark": "ownphotos-light",
+            "light": "ownphotos"
         }
     },
     "victoriametrics": {
@@ -21849,8 +21849,8 @@
             }
         },
         "colors": {
-            "dark": "victoriametrics",
-            "light": "victoriametrics-light"
+            "dark": "victoriametrics-light",
+            "light": "victoriametrics"
         }
     },
     "librum": {
@@ -22011,8 +22011,8 @@
             }
         },
         "colors": {
-            "dark": "synapse",
-            "light": "synapse-light"
+            "dark": "synapse-light",
+            "light": "synapse"
         }
     },
     "mailgun": {
@@ -22063,8 +22063,8 @@
             }
         },
         "colors": {
-            "dark": "jackett",
-            "light": "jackett-light"
+            "dark": "jackett-light",
+            "light": "jackett"
         }
     },
     "vmware-vcenter": {
@@ -22127,8 +22127,8 @@
             }
         },
         "colors": {
-            "dark": "music-assistant",
-            "light": "music-assistant-light"
+            "dark": "music-assistant-light",
+            "light": "music-assistant"
         }
     },
     "tasmoadmin": {
@@ -22227,8 +22227,8 @@
             }
         },
         "colors": {
-            "dark": "affine",
-            "light": "affine-light"
+            "dark": "affine-light",
+            "light": "affine"
         }
     },
     "vuplus": {
@@ -22255,8 +22255,8 @@
             }
         },
         "colors": {
-            "dark": "forte",
-            "light": "forte-light"
+            "dark": "forte-light",
+            "light": "forte"
         }
     },
     "mediux": {
@@ -22487,8 +22487,8 @@
             }
         },
         "colors": {
-            "dark": "solidtime",
-            "light": "solidtime-light"
+            "dark": "solidtime-light",
+            "light": "solidtime"
         }
     },
     "duplicati": {
@@ -22611,8 +22611,8 @@
             }
         },
         "colors": {
-            "dark": "servarr",
-            "light": "servarr-light"
+            "dark": "servarr-light",
+            "light": "servarr"
         }
     },
     "i2pd": {
@@ -22831,8 +22831,8 @@
             }
         },
         "colors": {
-            "dark": "esphome-alt",
-            "light": "esphome-alt-light"
+            "dark": "esphome-alt-light",
+            "light": "esphome-alt"
         }
     },
     "nextcloud-tables": {
@@ -23171,8 +23171,8 @@
             }
         },
         "colors": {
-            "dark": "typemill",
-            "light": "typemill-light"
+            "dark": "typemill-light",
+            "light": "typemill"
         }
     },
     "matterbridge": {
@@ -23433,8 +23433,8 @@
             }
         },
         "colors": {
-            "light": "fusionauth-light",
-            "dark": "fusionauth"
+            "light": "fusionauth",
+            "dark": "fusionauth-light"
         }
     },
     "netgear": {
@@ -23449,8 +23449,8 @@
             }
         },
         "colors": {
-            "dark": "netgear",
-            "light": "netgear-light"
+            "dark": "netgear-light",
+            "light": "netgear"
         }
     },
     "evcc": {
@@ -23549,8 +23549,8 @@
             }
         },
         "colors": {
-            "dark": "arris",
-            "light": "arris-light"
+            "dark": "arris-light",
+            "light": "arris"
         }
     },
     "oneuptime": {
@@ -23565,8 +23565,8 @@
             }
         },
         "colors": {
-            "dark": "oneuptime",
-            "light": "oneuptime-light"
+            "dark": "oneuptime-light",
+            "light": "oneuptime"
         }
     },
     "komga": {
@@ -23679,8 +23679,8 @@
             }
         },
         "colors": {
-            "dark": "haptic",
-            "light": "haptic-light"
+            "dark": "haptic-light",
+            "light": "haptic"
         }
     },
     "lemmy": {
@@ -23695,8 +23695,8 @@
             }
         },
         "colors": {
-            "dark": "lemmy",
-            "light": "lemmy-light"
+            "dark": "lemmy-light",
+            "light": "lemmy"
         }
     },
     "grandstream": {
@@ -23723,8 +23723,8 @@
             }
         },
         "colors": {
-            "dark": "coder",
-            "light": "coder-light"
+            "dark": "coder-light",
+            "light": "coder"
         }
     },
     "matter": {
@@ -23739,8 +23739,8 @@
             }
         },
         "colors": {
-            "dark": "matter",
-            "light": "matter-light"
+            "dark": "matter-light",
+            "light": "matter"
         }
     },
     "rompya": {
@@ -23833,8 +23833,8 @@
             }
         },
         "colors": {
-            "dark": "wolfi",
-            "light": "wolfi-light"
+            "dark": "wolfi-light",
+            "light": "wolfi"
         }
     },
     "yourls": {
@@ -23921,8 +23921,8 @@
             }
         },
         "colors": {
-            "dark": "matrix",
-            "light": "matrix-light"
+            "dark": "matrix-light",
+            "light": "matrix"
         }
     },
     "searx": {
@@ -24083,8 +24083,8 @@
             }
         },
         "colors": {
-            "dark": "teamcity",
-            "light": "teamcity-light"
+            "dark": "teamcity-light",
+            "light": "teamcity"
         }
     },
     "kleinanzeigen": {
@@ -24429,8 +24429,8 @@
             }
         },
         "colors": {
-            "dark": "matrix-synapse",
-            "light": "matrix-synapse-light"
+            "dark": "matrix-synapse-light",
+            "light": "matrix-synapse"
         }
     },
     "bar-assistant": {
@@ -24469,8 +24469,8 @@
             }
         },
         "colors": {
-            "dark": "medium-dark",
-            "light": "medium-light"
+            "dark": "medium-light",
+            "light": "medium-dark"
         }
     },
     "librenms": {
@@ -24497,8 +24497,8 @@
             }
         },
         "colors": {
-            "dark": "discourse",
-            "light": "discourse-light"
+            "dark": "discourse-light",
+            "light": "discourse"
         }
     },
     "balena-cloud": {
@@ -24539,8 +24539,8 @@
             }
         },
         "colors": {
-            "dark": "yamtrack",
-            "light": "yamtrack-light"
+            "dark": "yamtrack-light",
+            "light": "yamtrack"
         }
     },
     "qutebrowser": {
@@ -24627,8 +24627,8 @@
             }
         },
         "colors": {
-            "dark": "logitech",
-            "light": "logitech-light"
+            "dark": "logitech-light",
+            "light": "logitech"
         }
     },
     "airtable": {
@@ -24667,8 +24667,8 @@
             }
         },
         "colors": {
-            "dark": "codimd",
-            "light": "codimd-light"
+            "dark": "codimd-light",
+            "light": "codimd"
         }
     },
     "tube-archivist": {
@@ -24683,8 +24683,8 @@
             }
         },
         "colors": {
-            "dark": "tube-archivist",
-            "light": "tube-archivist-light"
+            "dark": "tube-archivist-light",
+            "light": "tube-archivist"
         }
     },
     "openaudible": {
@@ -24773,8 +24773,8 @@
             }
         },
         "colors": {
-            "dark": "biblioreads",
-            "light": "biblioreads-light"
+            "dark": "biblioreads-light",
+            "light": "biblioreads"
         }
     },
     "ombi": {
@@ -24985,8 +24985,8 @@
             }
         },
         "colors": {
-            "dark": "outline",
-            "light": "outline-light"
+            "dark": "outline-light",
+            "light": "outline"
         }
     },
     "chromium": {
@@ -25089,8 +25089,8 @@
             }
         },
         "colors": {
-            "dark": "tiddlywiki",
-            "light": "tiddlywiki-light"
+            "dark": "tiddlywiki-light",
+            "light": "tiddlywiki"
         }
     },
     "headscale": {
@@ -25153,8 +25153,8 @@
             }
         },
         "colors": {
-            "dark": "riverside-fm",
-            "light": "riverside-fm-light"
+            "dark": "riverside-fm-light",
+            "light": "riverside-fm"
         }
     },
     "nodejs": {
@@ -25193,8 +25193,8 @@
             }
         },
         "colors": {
-            "dark": "koillection",
-            "light": "koillection-light"
+            "dark": "koillection-light",
+            "light": "koillection"
         }
     },
     "amazon-web-services": {
@@ -25209,8 +25209,8 @@
             }
         },
         "colors": {
-            "dark": "amazon-web-services",
-            "light": "amazon-web-services-light"
+            "dark": "amazon-web-services-light",
+            "light": "amazon-web-services"
         }
     },
     "saltcorn": {
@@ -25311,8 +25311,8 @@
             }
         },
         "colors": {
-            "dark": "microsoft-sql-server",
-            "light": "microsoft-sql-server-light"
+            "dark": "microsoft-sql-server-light",
+            "light": "microsoft-sql-server"
         }
     },
     "nextcloud-deck": {
@@ -25387,8 +25387,8 @@
             }
         },
         "colors": {
-            "dark": "icinga-full",
-            "light": "icinga-full-light"
+            "dark": "icinga-full-light",
+            "light": "icinga-full"
         }
     },
     "borgmatic": {
@@ -25403,8 +25403,8 @@
             }
         },
         "colors": {
-            "dark": "borgmatic",
-            "light": "borgmatic-light"
+            "dark": "borgmatic-light",
+            "light": "borgmatic"
         }
     },
     "team-viewer": {
@@ -25551,8 +25551,8 @@
             }
         },
         "colors": {
-            "dark": "cups",
-            "light": "cups-light"
+            "dark": "cups-light",
+            "light": "cups"
         }
     },
     "appwrite": {
@@ -25591,8 +25591,8 @@
             }
         },
         "colors": {
-            "dark": "nzbhydra2",
-            "light": "nzbhydra2-light"
+            "dark": "nzbhydra2-light",
+            "light": "nzbhydra2"
         }
     },
     "unifi-protect": {
@@ -25715,8 +25715,8 @@
             }
         },
         "colors": {
-            "dark": "jwt-io",
-            "light": "jwt-io-light"
+            "dark": "jwt-io-light",
+            "light": "jwt-io"
         }
     },
     "sophos": {
@@ -25771,8 +25771,8 @@
             }
         },
         "colors": {
-            "dark": "payload",
-            "light": "payload-light"
+            "dark": "payload-light",
+            "light": "payload"
         }
     },
     "algo": {
@@ -25835,8 +25835,8 @@
             }
         },
         "colors": {
-            "dark": "aws",
-            "light": "aws-light"
+            "dark": "aws-light",
+            "light": "aws"
         }
     },
     "cilium": {
@@ -25851,8 +25851,8 @@
             }
         },
         "colors": {
-            "dark": "cilium",
-            "light": "cilium-light"
+            "dark": "cilium-light",
+            "light": "cilium"
         }
     },
     "requestly": {
@@ -26039,8 +26039,8 @@
             }
         },
         "colors": {
-            "dark": "part-db",
-            "light": "part-db-light"
+            "dark": "part-db-light",
+            "light": "part-db"
         }
     },
     "reactive-resume": {
@@ -26055,8 +26055,8 @@
             }
         },
         "colors": {
-            "dark": "reactive-resume",
-            "light": "reactive-resume-light"
+            "dark": "reactive-resume-light",
+            "light": "reactive-resume"
         }
     },
     "umbrel": {
@@ -26083,8 +26083,8 @@
             }
         },
         "colors": {
-            "dark": "mobotix",
-            "light": "mobotix-light"
+            "dark": "mobotix-light",
+            "light": "mobotix"
         }
     },
     "theodinproject": {
@@ -26123,8 +26123,8 @@
             }
         },
         "colors": {
-            "dark": "openemr",
-            "light": "openemr-light"
+            "dark": "openemr-light",
+            "light": "openemr"
         }
     },
     "opera-neon": {
@@ -26211,8 +26211,8 @@
             }
         },
         "colors": {
-            "dark": "libreoffice",
-            "light": "libreoffice-light"
+            "dark": "libreoffice-light",
+            "light": "libreoffice"
         }
     },
     "kaizoku": {
@@ -26387,8 +26387,8 @@
             }
         },
         "colors": {
-            "dark": "automad",
-            "light": "automad-light"
+            "dark": "automad-light",
+            "light": "automad"
         }
     },
     "schneider": {
@@ -26439,8 +26439,8 @@
             }
         },
         "colors": {
-            "dark": "myheats",
-            "light": "myheats-light"
+            "dark": "myheats-light",
+            "light": "myheats"
         }
     },
     "windows-95": {
@@ -26455,8 +26455,8 @@
             }
         },
         "colors": {
-            "dark": "windows-95",
-            "light": "windows-95-light"
+            "dark": "windows-95-light",
+            "light": "windows-95"
         }
     },
     "pgbackweb": {
@@ -26471,8 +26471,8 @@
             }
         },
         "colors": {
-            "dark": "pgbackweb-dark",
-            "light": "pgbackweb-light"
+            "dark": "pgbackweb-light",
+            "light": "pgbackweb-dark"
         }
     },
     "chiefonboarding": {
@@ -26535,8 +26535,8 @@
             }
         },
         "colors": {
-            "dark": "pingdom",
-            "light": "pingdom-light"
+            "dark": "pingdom-light",
+            "light": "pingdom"
         }
     },
     "netapp": {
@@ -26551,8 +26551,8 @@
             }
         },
         "colors": {
-            "dark": "netapp",
-            "light": "netapp-light"
+            "dark": "netapp-light",
+            "light": "netapp"
         }
     },
     "taskcafe": {
@@ -26579,8 +26579,8 @@
             }
         },
         "colors": {
-            "dark": "pwndrop",
-            "light": "pwndrop-light"
+            "dark": "pwndrop-light",
+            "light": "pwndrop"
         }
     },
     "wbo": {
@@ -26753,8 +26753,8 @@
             }
         },
         "colors": {
-            "dark": "vaultwarden",
-            "light": "vaultwarden-light"
+            "dark": "vaultwarden-light",
+            "light": "vaultwarden"
         }
     },
     "dokuwiki": {
@@ -26853,8 +26853,8 @@
             }
         },
         "colors": {
-            "dark": "phorge",
-            "light": "phorge-light"
+            "dark": "phorge-light",
+            "light": "phorge"
         }
     },
     "ward": {
@@ -26979,8 +26979,8 @@
             }
         },
         "colors": {
-            "light": "fenrus-light",
-            "dark": "fenrus"
+            "light": "fenrus",
+            "dark": "fenrus-light"
         }
     },
     "cribl": {
@@ -26995,8 +26995,8 @@
             }
         },
         "colors": {
-            "dark": "cribl",
-            "light": "cribl-light"
+            "dark": "cribl-light",
+            "light": "cribl"
         }
     },
     "deployarr": {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/96ad989d-820f-4dc7-a967-035139f24cae)

This pr resolves things like the aboce, so that "light theme" icons actually are visible with light backgrounds