### PR TITLE
feat: add PostHog instrumentation and harden error handling

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,10 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@opentelemetry/api-logs": "^0.216.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.216.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-logs": "^0.216.0",
     "@posthog/nextjs-config": "^1.9.16",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
+      '@opentelemetry/api-logs':
+        specifier: ^0.216.0
+        version: 0.216.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
       '@posthog/nextjs-config':
         specifier: ^1.9.16
         version: 1.9.16(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(webpack@5.106.2(esbuild@0.27.7))
@@ -772,6 +784,10 @@ packages:
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.216.0':
+    resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -794,14 +810,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-http@0.216.0':
+    resolution: {integrity: sha512-8SUzQY/aExKkz6Ab3vOf6gu690Xk4wHH90dGwXinejQzazn5HCIRR7yPVU/2fEuiZ73R92MU4qI3djHfYP7NJg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-exporter-base@0.208.0':
     resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.216.0':
+    resolution: {integrity: sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-transformer@0.208.0':
     resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.216.0':
+    resolution: {integrity: sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -824,14 +858,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.216.0':
+    resolution: {integrity: sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
   '@opentelemetry/sdk-metrics@2.2.0':
     resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.2.0':
     resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -2829,6 +2881,10 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -3689,6 +3745,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.216.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
 
   '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
@@ -3710,11 +3770,26 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-logs-otlp-http@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3726,6 +3801,17 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
       protobufjs: 7.5.6
+
+  '@opentelemetry/otlp-transformer@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3746,17 +3832,38 @@ snapshots:
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
@@ -5702,6 +5809,21 @@ snapshots:
       react-is: 16.13.1
 
   protobufjs@7.5.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.12.2
+      long: 5.3.2
+
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -74,7 +74,7 @@ function SubmissionStatusBadge({ status }: { status: Submission["status"] }) {
 		rejected: { label: "Rejected", className: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20" },
 		added_to_collection: { label: "Live", className: "bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20" },
 	}
-	const { label, className } = config[status]
+	const { label, className } = config[status] ?? { label: status, className: "bg-gray-500/10 text-gray-500 border-gray-500/20" }
 	return (
 		<Badge variant="outline" className={`text-xs ${className}`}>
 			{label}

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, ArrowLeft, RefreshCcw } from "lucide-react"
 import { useRouter } from "next/navigation"
+import posthog from "posthog-js"
 import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
 
@@ -9,8 +10,7 @@ export default function ErrorPage({ error, reset }: { error: Error & { digest?: 
 	const router = useRouter()
 
 	useEffect(() => {
-		// Log the error to an error reporting service
-		console.error("Application error:", error)
+		posthog.captureException(error)
 	}, [error])
 
 	const handleGoBack = () => {

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import posthog from "posthog-js"
+import NextError from "next/error"
+import { useEffect } from "react"
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+	useEffect(() => {
+		posthog.captureException(error)
+	}, [error])
+
+	return (
+		<html lang="en">
+			<body>
+				<NextError statusCode={0} />
+			</body>
+		</html>
+	)
+}

--- a/web/src/app/icons/external/[slug]/page.tsx
+++ b/web/src/app/icons/external/[slug]/page.tsx
@@ -36,6 +36,9 @@ export async function generateMetadata({ params }: Props, _parent: ResolvingMeta
 	}
 
 	const sourceConfig = EXTERNAL_SOURCES[icon.external.source as ExternalSourceId]
+	if (!sourceConfig) {
+		notFound()
+	}
 	const formattedName = icon.external.name
 	const pageUrl = `${WEB_URL}/icons/external/${slug}`
 	const previewUrl = getExternalIconPreviewUrl(icon.external)
@@ -108,6 +111,9 @@ export default async function ExternalIconPage({ params }: { params: Promise<{ s
 	}
 
 	const sourceConfig = EXTERNAL_SOURCES[icon.external.source as ExternalSourceId]
+	if (!sourceConfig) {
+		notFound()
+	}
 	const previewUrl = getExternalIconPreviewUrl(icon.external)
 
 	const authorData: AuthorData = {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -4,12 +4,16 @@ import { REPO_NAME, WEB_URL } from "@/constants"
 import { getRecentlyAddedIcons, getTotalIcons } from "@/lib/api"
 
 async function getGitHubStars() {
-	const response = await fetch(`https://api.github.com/repos/${REPO_NAME}`, {
-		next: { revalidate: 3600 },
-	})
-	const data = await response.json()
-	console.log(`GitHub stars: ${data.stargazers_count}`)
-	return data.stargazers_count
+	try {
+		const response = await fetch(`https://api.github.com/repos/${REPO_NAME}`, {
+			next: { revalidate: 3600 },
+		})
+		if (!response.ok) return 0
+		const data = await response.json()
+		return data.stargazers_count ?? 0
+	} catch {
+		return 0
+	}
 }
 
 export default async function Home() {

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -9,7 +9,7 @@ export const revalidate = 21600
 
 // Helper function to format dates as YYYY-MM-DD
 const formatDate = (date: Date): string => {
-	// Format to YYYY-MM-DD
+	if (Number.isNaN(date.getTime())) return new Date().toISOString().split("T")[0]
 	return date.toISOString().split("T")[0]
 }
 

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -9,7 +9,7 @@ export const revalidate = 21600
 
 // Helper function to format dates as YYYY-MM-DD
 const formatDate = (date: Date): string => {
-	if (Number.isNaN(date.getTime())) return new Date().toISOString().split("T")[0]
+	if (Number.isNaN(date.getTime())) return "2024-01-01"
 	return date.toISOString().split("T")[0]
 }
 

--- a/web/src/components/add-to-search-bar-button.tsx
+++ b/web/src/components/add-to-search-bar-button.tsx
@@ -72,9 +72,7 @@ export function AddToSearchBarButton({ size = "default", className }: { size?: "
 			<DialogTrigger asChild>
 				<Button variant="outline" size={size} className={cn("shadow-sm cursor-pointer", className)}>
 					<Search className="h-4 w-4" />
-					<span className="hidden sm:inline text-foreground transition-all duration-300 group-hover:scale-105">
-						Search from browser
-					</span>
+					<span className="hidden sm:inline text-foreground transition-all duration-300 group-hover:scale-105">Search from browser</span>
 					<span className="sm:hidden">Browser search</span>
 				</Button>
 			</DialogTrigger>

--- a/web/src/components/carbon.tsx
+++ b/web/src/components/carbon.tsx
@@ -89,8 +89,7 @@ export function Carbon() {
 						className="rounded-md border border-dashed border-border bg-muted/40 px-3 py-6 text-center text-[11px] leading-snug text-muted-foreground"
 						data-carbon-placeholder
 					>
-						Carbon ad (shown on production only — localhost is usually not filled by
-						Carbon)
+						Carbon ad (shown on production only — localhost is usually not filled by Carbon)
 					</div>
 				) : (
 					<div ref={ref} className="carbon-outer" />

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -15,6 +15,7 @@ import { resetPostHogIdentity } from "@/lib/posthog-utils"
 import type { IconWithName } from "@/types/icons"
 
 const CommandMenu = dynamic(() => import("./command-menu").then((mod) => mod.CommandMenu), { ssr: false })
+
 import { HeaderNav } from "./header-nav"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import { Button } from "./ui/button"

--- a/web/src/components/icon-details.tsx
+++ b/web/src/components/icon-details.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "framer-motion"
 import { ArrowRight, Check, ExternalLink, FileType, Github, Moon, Palette, PaletteIcon, Sun, Type } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
+import posthog from "posthog-js"
 import type React from "react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
@@ -291,6 +292,11 @@ export function IconDetails({
 		try {
 			await navigator.clipboard.writeText(url)
 			setCopiedUrlKey(variantKey)
+			posthog.capture("icon_url_copied", {
+				icon_name: icon,
+				variant: variantKey,
+				is_external: isExternalIcon,
+			})
 			setTimeout(() => {
 				setCopiedUrlKey(null)
 			}, 2000)
@@ -347,6 +353,12 @@ export function IconDetails({
 					launchConfetti()
 				}
 
+				posthog.capture("icon_image_copied", {
+					icon_name: icon,
+					format: "svg",
+					variant: variantKey,
+					is_external: isExternalIcon,
+				})
 				toast.dismiss()
 				toast.success("SVG Markup Copied", {
 					description: "The SVG code has been copied to your clipboard.",
@@ -376,6 +388,12 @@ export function IconDetails({
 					launchConfetti()
 				}
 
+				posthog.capture("icon_image_copied", {
+					icon_name: icon,
+					format,
+					variant: variantKey,
+					is_external: isExternalIcon,
+				})
 				toast.dismiss()
 				toast.success("Image copied", {
 					description: `The ${format.toUpperCase()} image has been copied to your clipboard.`,
@@ -411,7 +429,6 @@ export function IconDetails({
 			const blobUrl = URL.createObjectURL(blob)
 			const link = document.createElement("a")
 			link.href = blobUrl
-			// Sanitize filename
 			const sanitizedFilename = filename
 				.replace(/[^a-z0-9.-]/gi, "-")
 				.replace(/-+/g, "-")
@@ -421,6 +438,13 @@ export function IconDetails({
 			link.click()
 			document.body.removeChild(link)
 			setTimeout(() => URL.revokeObjectURL(blobUrl), 100)
+
+			const format = filename.split(".").pop() || "unknown"
+			posthog.capture("icon_downloaded", {
+				icon_name: icon,
+				format,
+				is_external: isExternalIcon,
+			})
 
 			toast.dismiss()
 			toast.success("Download started", {

--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -1,0 +1,75 @@
+import { PostHog } from "posthog-node"
+import type { LoggerProvider } from "@opentelemetry/sdk-logs"
+
+let posthogClient: PostHog | null = null
+export let loggerProvider: LoggerProvider | null = null
+
+function getPostHogClient(): PostHog | null {
+	const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+	if (!key) return null
+	if (!posthogClient) {
+		posthogClient = new PostHog(key, {
+			host: "https://eu.i.posthog.com",
+			flushAt: 1,
+			flushInterval: 0,
+		})
+	}
+	return posthogClient
+}
+
+export async function register() {
+	if (process.env.NEXT_RUNTIME === "nodejs" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+		const { BatchLogRecordProcessor: Processor, LoggerProvider: Provider } = await import(
+			"@opentelemetry/sdk-logs"
+		)
+		const { OTLPLogExporter } = await import("@opentelemetry/exporter-logs-otlp-http")
+		const { logs } = await import("@opentelemetry/api-logs")
+		const { resourceFromAttributes } = await import("@opentelemetry/resources")
+
+		loggerProvider = new Provider({
+			resource: resourceFromAttributes({ "service.name": "dashboard-icons-web" }),
+			processors: [
+				new Processor(
+					new OTLPLogExporter({
+						url: "https://eu.i.posthog.com/i/v1/logs",
+						headers: {
+							Authorization: `Bearer ${process.env.NEXT_PUBLIC_POSTHOG_KEY}`,
+							"Content-Type": "application/json",
+						},
+					}),
+				),
+			],
+		})
+
+		logs.setGlobalLoggerProvider(loggerProvider)
+	}
+}
+
+export async function onRequestError(
+	error: Error & { digest?: string },
+	request: { path: string; method: string; headers: Record<string, string> },
+	context: { routerKind: string; routePath: string; routeType: string; renderSource: string },
+) {
+	if (error.message?.includes("NoFallbackError")) return
+
+	const posthog = getPostHogClient()
+	if (!posthog) return
+
+	posthog.capture({
+		distinctId: "server",
+		event: "$exception",
+		properties: {
+			$exception_message: error.message,
+			$exception_type: error.name,
+			$exception_stack_trace_raw: error.stack,
+			path: request.path,
+			method: request.method,
+			routerKind: context.routerKind,
+			routePath: context.routePath,
+			routeType: context.routeType,
+			renderSource: context.renderSource,
+			digest: error.digest,
+		},
+	})
+	await posthog.flush()
+}

--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -49,6 +49,20 @@ export async function register() {
 	}
 }
 
+function extractDistinctId(headers: Record<string, string>): string | undefined {
+	const cookie = headers.cookie
+	if (!cookie) return undefined
+	const cookieString = Array.isArray(cookie) ? cookie.join("; ") : cookie
+	const match = cookieString.match(/ph_phc_.*?_posthog=([^;]+)/)
+	if (!match?.[1]) return undefined
+	try {
+		const data = JSON.parse(decodeURIComponent(match[1]))
+		return data.distinct_id
+	} catch {
+		return undefined
+	}
+}
+
 export async function onRequestError(
 	error: Error & { digest?: string },
 	request: { path: string; method: string; headers: Record<string, string> },
@@ -59,13 +73,10 @@ export async function onRequestError(
 	const posthog = getPostHogClient()
 	if (!posthog) return
 
-	posthog.capture({
-		distinctId: "server",
-		event: "$exception",
+	const distinctId = extractDistinctId(request.headers)
+
+	posthog.captureException(error, distinctId, {
 		properties: {
-			$exception_message: error.message,
-			$exception_type: error.name,
-			$exception_stack_trace_raw: error.stack,
 			path: request.path,
 			method: request.method,
 			routerKind: context.routerKind,

--- a/web/src/instrumentation.ts
+++ b/web/src/instrumentation.ts
@@ -6,7 +6,7 @@ export let loggerProvider: LoggerProvider | null = null
 
 function getPostHogClient(): PostHog | null {
 	const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
-	if (!key) return null
+	if (!key || process.env.NEXT_PUBLIC_DISABLE_POSTHOG === "true") return null
 	if (!posthogClient) {
 		posthogClient = new PostHog(key, {
 			host: "https://eu.i.posthog.com",
@@ -18,7 +18,11 @@ function getPostHogClient(): PostHog | null {
 }
 
 export async function register() {
-	if (process.env.NEXT_RUNTIME === "nodejs" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+	if (
+		process.env.NEXT_RUNTIME === "nodejs" &&
+		process.env.NEXT_PUBLIC_POSTHOG_KEY &&
+		process.env.NEXT_PUBLIC_DISABLE_POSTHOG !== "true"
+	) {
 		const { BatchLogRecordProcessor: Processor, LoggerProvider: Provider } = await import(
 			"@opentelemetry/sdk-logs"
 		)
@@ -71,5 +75,5 @@ export async function onRequestError(
 			digest: error.digest,
 		},
 	})
-	await posthog.flush()
+	posthog.flush().catch(() => {})
 }

--- a/web/src/lib/community.ts
+++ b/web/src/lib/community.ts
@@ -140,13 +140,7 @@ async function fetchCommunitySubmissionByName(name: string): Promise<IconWithNam
 		const pb = createServerPB()
 
 		const record = await pb.collection("community_gallery").getFirstListItem<CommunityGallery>(`name="${name}"`)
-		console.log("[Community] Record author fields:", {
-			name,
-			created_by: record.created_by,
-			created_by_github_id: record.created_by_github_id,
-		})
 		const transformed = transformGalleryToIcon(record)
-		console.log(`[Community] Fetched ${name}, colors:`, transformed.data.colors)
 		return transformed
 	} catch (error) {
 		console.error(`Error fetching community submission ${name}:`, error)


### PR DESCRIPTION
## Summary
- **PostHog instrumentation**: Added `src/instrumentation.ts` with OpenTelemetry log drains (OTLP to PostHog EU) and `onRequestError` hook for server-side exception tracking. `NoFallbackError` is filtered out since it's expected Next.js 404 behavior.
- **Error handling hardening**: Fixed unhandled crashes in `getGitHubStars` (home page), `formatDate` (sitemap RangeError), `SubmissionStatusBadge` (unknown status destructure), and external icon page (unknown source config). Removed noisy `console.log` spam from community icon fetches.
- **PostHog analytics events**: Added tracking for `icon_url_copied`, `icon_image_copied`, and `icon_downloaded` in the icon details component.

## Test plan
- [ ] Verify home page renders when GitHub API is down (stars should show 0)
- [ ] Verify sitemap generates without errors for icons with missing timestamps
- [ ] Verify external icon pages 404 gracefully for unknown sources
- [ ] Verify dashboard page handles unexpected submission statuses
- [ ] Check PostHog logs tab for incoming log entries after deploy
- [ ] Check PostHog error tracking for server exceptions after deploy