### PR TITLE
Security: Fix 1 finding in GitHub Actions workflows

### DIFF
--- a/.github/workflows/validate_and_preview_icons.yml
+++ b/.github/workflows/validate_and_preview_icons.yml
@@ -63,12 +63,14 @@ jobs:
 
       - name: Generate Icon Previews
         id: preview
+        env:
+            PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           ICONS=$(find png/ -type f -name "*.png")
           PREVIEWS=""
           for ICON in $ICONS; do
             ICON_NAME=$(basename $ICON)
-            PREVIEW="![${ICON_NAME}](https://raw.githubusercontent.com/homarr-labs/dashboard-icons/${{ github.event.pull_request.head.ref }}/png/${ICON_NAME})"
+            PREVIEW="![${ICON_NAME}](https://raw.githubusercontent.com/homarr-labs/dashboard-icons/$PR_HEAD_REF/png/${ICON_NAME})"
             PREVIEWS="$PREVIEWS $PREVIEW"
           done
           echo "::set-output name=icon_previews::$PREVIEWS"


### PR DESCRIPTION
## Security: 1 finding across 1 rule

### Fixed (deterministic, no AI)

**shell-injection-expr** — [What is this?](https://sentinel-bot.copilotkit.dev/rules/shell-injection-expr)
- `validate_and_preview_icons.yml` line 71: Attacker-controllable expression ${{ github.event.pull_request.head.ref }} in run: block — shell injection risk

### How this was detected

This finding was identified by deterministic pattern matching — no AI or machine learning was used in the detection. Sentinel uses static analysis rules that match known-vulnerable YAML patterns against a database of documented exploit vectors. Every finding maps to a specific, reproducible pattern. [Source code](https://github.com/jpr5/sentinel) is open for inspection.

---
<sub>&#x1f6e1;&#xfe0f; This PR was generated by [Sentinel](https://sentinel.copilotkit.dev), an open-source security scanner. [Why this PR?](https://medium.com/@jordanritter/security-hardening-github-workflows-at-scale-d291a33774e1) · Free, no tracking</sub>

[&#x2705; Add Sentinel to this repo](https://sentinel-bot.copilotkit.dev/adopt?repo=homarr-labs%2Fdashboard-icons&token=06157dde-0222-4e57-8bfc-c00f4f4fb907) · [&#x1f6ab; Opt out of future PRs](https://sentinel-bot.copilotkit.dev/opt-out?repo=homarr-labs%2Fdashboard-icons&token=4047b664-0496-41e9-a8c4-894f9ce3ff03)
