### PR TITLE
Improve AEO and SEO for AI answer engines

### DIFF
--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,0 +1,19 @@
+# Dashboard Icons
+> Free curated icons and logos for dashboards and app directories.
+
+## Pages
+- / — Homepage with search and recently added icons
+- /icons — Browse and search the full icon collection
+- /community — Community-submitted icons awaiting review
+- /license — License and trademark policy
+- /icons/{slug} — Download individual native icon (SVG, PNG, WEBP)
+- /icons/external/{slug} — Download external source icons
+- /community/{slug} — Community icon detail pages
+
+## Facts
+- License: CC BY 4.0 for native Dashboard Icons
+- Maintainer: Homarr Labs
+- CDN: cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons
+- GitHub: github.com/homarr-labs/dashboard-icons
+- Formats: SVG, PNG, WEBP
+- Contact: homarr-labs@proton.me

--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -3,18 +3,12 @@
 	"short_name": "DashIcons",
 	"description": "A collection of curated icons for services, applications and tools, designed specifically for dashboards and app directories.",
 	"icons": [
-    {
-      "src": "/web-app-manifest-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/web-app-manifest-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    }		
+		{
+			"src": "/favicon.svg",
+			"sizes": "any",
+			"type": "image/svg+xml",
+			"purpose": "any"
+		}
 	],
 	"theme_color": "#FA5252",
 	"background_color": "#1B1B1D",

--- a/web/src/app/community/[icon]/page.tsx
+++ b/web/src/app/community/[icon]/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata, ResolvingMetadata } from "next"
 import { notFound, permanentRedirect } from "next/navigation"
 import { IconDetails } from "@/components/icon-details"
+import { JsonLd } from "@/components/seo/json-ld"
 import { BASE_URL, WEB_URL } from "@/constants"
 import { computeRelatedIcons, getAllIcons, getAuthorData } from "@/lib/api"
 import { getCommunityGalleryRecord, getCommunitySubmissionByName, getCommunitySubmissions } from "@/lib/community"
+import { buildIconPageGraph } from "@/lib/seo/schemas"
 
 function isIconAddedToCollection(
 	record: Awaited<ReturnType<typeof getCommunityGalleryRecord>>,
@@ -103,6 +105,13 @@ export async function generateMetadata({ params }: Props, _parent: ResolvingMeta
 			locale: "en_US",
 			images: [
 				{
+					url: `${WEB_URL}/og/community/${icon}`,
+					width: 1200,
+					height: 630,
+					alt: `${formattedIconName} community icon`,
+					type: "image/png",
+				},
+				{
 					url: mainIconUrl,
 					width: 512,
 					height: 512,
@@ -115,7 +124,7 @@ export async function generateMetadata({ params }: Props, _parent: ResolvingMeta
 			card: "summary_large_image",
 			title: `${formattedIconName} Icon & Logo (Community)`,
 			description: `Download the ${formattedIconName} community-submitted icon and logo. Part of a collection of ${totalIcons} community icons and logos awaiting review and addition to the Dashboard Icons collection.`,
-			images: [mainIconUrl],
+			images: [`${WEB_URL}/og/community/${icon}`],
 		},
 		alternates: {
 			canonical: `${WEB_URL}/community/${icon}`,
@@ -251,41 +260,30 @@ export default async function CommunityIconPage({ params }: { params: Promise<{ 
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(" ")
 
+	const pageUrl = `${WEB_URL}/community/${icon}`
+	const pageDescription = `Download the ${formattedName} community-submitted icon and logo. Part of a collection of community icons awaiting review and addition to the Dashboard Icons collection.`
+	const authorName = authorData.name || authorData.login
+
 	return (
 		<>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@type": "ImageObject",
-						contentUrl: mainIconUrl,
-						license: "https://creativecommons.org/licenses/by/4.0/",
-						acquireLicensePage: `${WEB_URL}/license`,
-						creditText: `Icon by ${authorData.name || authorData.login}`,
-						copyrightNotice: "© Homarr Labs",
-						creator: {
-							"@type": "Person",
-							name: authorData.name || authorData.login,
-						},
-					}).replace(/</g, "\\u003c"),
-				}}
-			/>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@type": "BreadcrumbList",
-						itemListElement: [
-							{ "@type": "ListItem", position: 1, name: "Home", item: WEB_URL },
-							{ "@type": "ListItem", position: 2, name: "Community Icons", item: `${WEB_URL}/community` },
-							{ "@type": "ListItem", position: 3, name: `${formattedName} Icon`, item: `${WEB_URL}/community/${icon}` },
-						],
-					}).replace(/</g, "\\u003c"),
-				}}
+			<JsonLd
+				data={buildIconPageGraph({
+					pageUrl,
+					pageName: `${formattedName} Icon & Logo (Community)`,
+					pageDescription,
+					dateModified: iconData.data.update.timestamp,
+					contentUrl: mainIconUrl,
+					licenseKey: "CC BY 4.0",
+					formattedName,
+					creator: { type: "Person", name: authorName, url: authorData.html_url || undefined },
+					creditText: `Icon by ${authorName}`,
+					copyrightNotice: "© Homarr Labs",
+					breadcrumbs: [
+						{ name: "Home", item: WEB_URL },
+						{ name: "Community Icons", item: `${WEB_URL}/community` },
+						{ name: `${formattedName} Icon`, item: pageUrl },
+					],
+				})}
 			/>
 			<IconDetails
 				breadcrumbItems={[

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -1,18 +1,26 @@
 import type { Metadata } from "next"
 import { Suspense } from "react"
 import { CommunityIconSearch } from "@/components/community-icon-search"
+import { JsonLd } from "@/components/seo/json-ld"
 import { WEB_URL } from "@/constants"
 import { fetchCommunitySubmissions, getCommunitySubmissions } from "@/lib/community"
+import { buildDefaultOgImages, buildDefaultTwitterImages, getFilteredBrowseMetadata } from "@/lib/seo/metadata"
+import { buildCommunityBrowseGraph } from "@/lib/seo/schemas"
 
 export const revalidate = 300
 
-export async function generateMetadata(): Promise<Metadata> {
-	const icons = await getCommunitySubmissions()
+type Props = {
+	searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+	const [icons, params] = await Promise.all([getCommunitySubmissions(), searchParams])
 	const totalIcons = icons.length
+	const description = `Search and browse through ${totalIcons} community-submitted icons and logos awaiting review and addition to the Dashboard Icons collection.`
 
 	return {
 		title: "Browse Community Icons & Logos",
-		description: `Search and browse through ${totalIcons} community-submitted icons and logos awaiting review and addition to the Dashboard Icons collection.`,
+		description,
 		keywords: [
 			"community icons",
 			"community logos",
@@ -27,34 +35,39 @@ export async function generateMetadata(): Promise<Metadata> {
 		],
 		openGraph: {
 			title: "Browse Community Icons & Logos",
-			description: `Search and browse through ${totalIcons} community-submitted icons and logos awaiting review and addition to the Dashboard Icons collection.`,
+			description,
 			type: "website",
 			url: `${WEB_URL}/community`,
+			images: buildDefaultOgImages("Browse Community Dashboard Icons"),
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: "Browse Community Icons & Logos",
-			description: `Search and browse through ${totalIcons} community-submitted icons and logos awaiting review and addition to the Dashboard Icons collection.`,
+			description,
+			images: buildDefaultTwitterImages(),
 		},
-		alternates: {
-			canonical: `${WEB_URL}/community`,
-		},
+		...getFilteredBrowseMetadata(params, "/community"),
 	}
 }
 
 export default async function CommunityPage() {
 	const icons = await fetchCommunitySubmissions()
+	const description = `Search and browse through ${icons.length} community-submitted icons and logos awaiting review and addition to the Dashboard Icons collection.`
+
 	return (
-		<div className="isolate overflow-hidden p-2 mx-auto max-w-7xl">
-			<div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-				<div>
-					<h1 className="text-3xl font-bold">Browse community icons & logos</h1>
-					<p className="text-muted-foreground mb-1">Search through our collection of {icons.length} community-submitted icons and logos.</p>
+		<>
+			<JsonLd data={buildCommunityBrowseGraph({ description, totalItems: icons.length })} />
+			<div className="isolate overflow-hidden p-2 mx-auto max-w-7xl">
+				<div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+					<div>
+						<h1 className="text-3xl font-bold">Browse community icons & logos</h1>
+						<p className="text-muted-foreground mb-1">Search through our collection of {icons.length} community-submitted icons and logos.</p>
+					</div>
 				</div>
+				<Suspense fallback={<div className="text-muted-foreground">Loading...</div>}>
+					<CommunityIconSearch icons={icons as any} />
+				</Suspense>
 			</div>
-			<Suspense fallback={<div className="text-muted-foreground">Loading...</div>}>
-				<CommunityIconSearch icons={icons as any} />
-			</Suspense>
-		</div>
+		</>
 	)
 }

--- a/web/src/app/icons/[icon]/page.tsx
+++ b/web/src/app/icons/[icon]/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata, ResolvingMetadata } from "next"
 import { notFound } from "next/navigation"
 import { IconDetails } from "@/components/icon-details"
+import { JsonLd } from "@/components/seo/json-ld"
 import { BASE_URL, WEB_URL } from "@/constants"
 import { computeRelatedIcons, getAllIcons, getAuthorData } from "@/lib/api"
+import { buildIconPageGraph } from "@/lib/seo/schemas"
 
 export const dynamicParams = false
 export const revalidate = false
@@ -134,41 +136,31 @@ export default async function IconPage({ params }: { params: Promise<{ icon: str
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(" ")
 
+	const pageUrl = `${WEB_URL}/icons/${icon}`
+	const pageDescription = `Download the ${formattedName} icon and logo in SVG, PNG, and WEBP formats for FREE. Part of a collection of curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`
+	const authorName = authorData.name || authorData.login
+
 	return (
 		<>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@type": "ImageObject",
-						contentUrl: `${BASE_URL}/png/${icon}.png`,
-						license: "https://creativecommons.org/licenses/by/4.0/",
-						acquireLicensePage: `${WEB_URL}/license`,
-						creditText: `Icon by ${authorData.name || authorData.login}`,
-						copyrightNotice: "© Homarr Labs",
-						creator: {
-							"@type": "Person",
-							name: authorData.name || authorData.login,
-						},
-					}).replace(/</g, "\\u003c"),
-				}}
-			/>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@type": "BreadcrumbList",
-						itemListElement: [
-							{ "@type": "ListItem", position: 1, name: "Home", item: WEB_URL },
-							{ "@type": "ListItem", position: 2, name: "Browse Icons", item: `${WEB_URL}/icons` },
-							{ "@type": "ListItem", position: 3, name: `${formattedName} Icon`, item: `${WEB_URL}/icons/${icon}` },
-						],
-					}).replace(/</g, "\\u003c"),
-				}}
+			<JsonLd
+				data={buildIconPageGraph({
+					pageUrl,
+					pageName: `${formattedName} Icon & Logo`,
+					pageDescription,
+					dateModified: originalIconData.update.timestamp,
+					contentUrl: `${BASE_URL}/png/${icon}.png`,
+					licenseKey: "CC BY 4.0",
+					formattedName,
+					creator: { type: "Person", name: authorName, url: authorData.html_url },
+					creditText: `Icon by ${authorName}`,
+					copyrightNotice: "© Homarr Labs",
+					breadcrumbs: [
+						{ name: "Home", item: WEB_URL },
+						{ name: "Browse Icons", item: `${WEB_URL}/icons` },
+						{ name: `${formattedName} Icon`, item: pageUrl },
+					],
+					encodingFormat: "image/png",
+				})}
 			/>
 			<IconDetails
 				breadcrumbItems={[

--- a/web/src/app/icons/external/[slug]/page.tsx
+++ b/web/src/app/icons/external/[slug]/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata, ResolvingMetadata } from "next"
 import { notFound } from "next/navigation"
 import { IconDetails } from "@/components/icon-details"
+import { JsonLd } from "@/components/seo/json-ld"
 import { EXTERNAL_SOURCES, type ExternalSourceId, WEB_URL } from "@/constants"
 import { getExternalIconPreviewUrl, resolveExternalIconUrl } from "@/lib/external-icon-urls"
 import { getExternalIconBySlug, getExternalIcons } from "@/lib/external-icons"
+import { buildIconPageGraph, resolveLicenseKey } from "@/lib/seo/schemas"
 import type { AuthorData } from "@/types/icons"
 
 export const dynamicParams = false
@@ -131,46 +133,30 @@ export default async function ExternalIconPage({ params }: { params: Promise<{ s
 		html_url: sourceConfig.authorUrl,
 	}
 
+	const pageUrl = `${WEB_URL}/icons/external/${slug}`
+	const pageDescription = `Download the ${icon.external.name} icon and logo from ${sourceConfig.label}. Licensed under ${sourceConfig.license}.`
+	const updatedAt =
+		icon.external.updated_at_source || icon.external.updated || icon.external.created || new Date().toISOString()
+
 	return (
 		<>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@type": "ImageObject",
-						contentUrl: previewUrl,
-						license:
-							sourceConfig.license === "MIT" ? "https://opensource.org/licenses/MIT" : "https://creativecommons.org/licenses/by/4.0/",
-						acquireLicensePage: `${WEB_URL}/license`,
-						creator: {
-							"@type": "Organization",
-							name: sourceConfig.authorName,
-							url: sourceConfig.authorUrl,
-						},
-					}).replace(/</g, "\\u003c"),
-				}}
-			/>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{
-					__html: JSON.stringify({
-						"@context": "https://schema.org",
-						"@type": "BreadcrumbList",
-						itemListElement: [
-							{ "@type": "ListItem", position: 1, name: "Home", item: WEB_URL },
-							{ "@type": "ListItem", position: 2, name: "Browse Icons", item: `${WEB_URL}/icons` },
-							{
-								"@type": "ListItem",
-								position: 3,
-								name: `${icon.external.name} Icon`,
-								item: `${WEB_URL}/icons/external/${slug}`,
-							},
-						],
-					}).replace(/</g, "\\u003c"),
-				}}
+			<JsonLd
+				data={buildIconPageGraph({
+					pageUrl,
+					pageName: `${icon.external.name} Icon & Logo (${sourceConfig.label})`,
+					pageDescription,
+					dateModified: updatedAt,
+					contentUrl: previewUrl,
+					licenseKey: resolveLicenseKey(sourceConfig.license),
+					formattedName: icon.external.name,
+					creator: { type: "Organization", name: sourceConfig.authorName, url: sourceConfig.authorUrl },
+					breadcrumbs: [
+						{ name: "Home", item: WEB_URL },
+						{ name: "Browse Icons", item: `${WEB_URL}/icons` },
+						{ name: sourceConfig.label, item: `${WEB_URL}/icons?source=${sourceConfig.id}` },
+						{ name: `${icon.external.name} Icon`, item: pageUrl },
+					],
+				})}
 			/>
 			<IconDetails
 				icon={icon.external.slug}

--- a/web/src/app/icons/page.tsx
+++ b/web/src/app/icons/page.tsx
@@ -1,16 +1,25 @@
 import type { Metadata } from "next"
+import { Suspense } from "react"
 import { IconSearch } from "@/components/icon-search"
+import { JsonLd } from "@/components/seo/json-ld"
 import { EXTERNAL_SOURCE_IDS, EXTERNAL_SOURCES, WEB_URL } from "@/constants"
 import { getIconsArray } from "@/lib/api"
 import { getExternalIcons } from "@/lib/external-icons"
+import { buildDefaultOgImages, buildDefaultTwitterImages, getFilteredBrowseMetadata } from "@/lib/seo/metadata"
+import { buildIconsBrowseGraph } from "@/lib/seo/schemas"
 
-export async function generateMetadata(): Promise<Metadata> {
-	const [nativeIcons, externalIcons] = await Promise.all([getIconsArray(), getExternalIcons()])
+type Props = {
+	searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+	const [nativeIcons, externalIcons, params] = await Promise.all([getIconsArray(), getExternalIcons(), searchParams])
 	const totalIcons = nativeIcons.length + externalIcons.length
+	const description = `Search and browse through our collection of ${totalIcons} curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`
 
 	return {
 		title: "Browse Icons & Logos",
-		description: `Search and browse through our collection of ${totalIcons} curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`,
+		description,
 		keywords: [
 			"browse icons",
 			"browse logos",
@@ -27,40 +36,46 @@ export async function generateMetadata(): Promise<Metadata> {
 		],
 		openGraph: {
 			title: "Browse Icons & Logos",
-			description: `Search and browse through our collection of ${totalIcons} curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`,
+			description,
 			type: "website",
 			url: `${WEB_URL}/icons`,
+			images: buildDefaultOgImages("Browse Dashboard Icons & Logos"),
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: "Browse Icons & Logos",
-			description: `Search and browse through our collection of ${totalIcons} curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`,
+			description,
+			images: buildDefaultTwitterImages(),
 		},
-		alternates: {
-			canonical: `${WEB_URL}/icons`,
-		},
+		...getFilteredBrowseMetadata(params, "/icons"),
 	}
 }
 
-export const dynamic = "force-static"
 export const revalidate = 21600
 
 export default async function IconsPage() {
 	const [nativeIcons, externalIcons] = await Promise.all([getIconsArray(), getExternalIcons()])
 	const icons = [...nativeIcons, ...externalIcons]
+	const description = `Search and browse through our collection of ${icons.length} curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`
+
 	return (
-		<div className="isolate overflow-hidden p-2 mx-auto max-w-7xl">
-			<div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-				<div>
-					<h1 className="text-3xl font-bold">Browse icons & logos</h1>
-					<p className="text-muted-foreground mb-1">
-						Search through {icons.length} icons and logos from Dashboard Icons
-						{EXTERNAL_SOURCE_IDS.length > 0 && ` and ${EXTERNAL_SOURCE_IDS.map((id) => EXTERNAL_SOURCES[id].label).join(", ")}`}.{" "}
-						{nativeIcons.length} are native Dashboard Icons.
-					</p>
+		<>
+			<JsonLd data={buildIconsBrowseGraph({ description, totalItems: icons.length })} />
+			<div className="isolate overflow-hidden p-2 mx-auto max-w-7xl">
+				<div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+					<div>
+						<h1 className="text-3xl font-bold">Browse icons & logos</h1>
+						<p className="text-muted-foreground mb-1">
+							Search through {icons.length} icons and logos from Dashboard Icons
+							{EXTERNAL_SOURCE_IDS.length > 0 && ` and ${EXTERNAL_SOURCE_IDS.map((id) => EXTERNAL_SOURCES[id].label).join(", ")}`}.{" "}
+							{nativeIcons.length} are native Dashboard Icons.
+						</p>
+					</div>
 				</div>
+				<Suspense fallback={<div className="text-muted-foreground">Loading...</div>}>
+					<IconSearch icons={icons} />
+				</Suspense>
 			</div>
-			<IconSearch icons={icons} />
-		</div>
+		</>
 	)
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -5,8 +5,11 @@ import { Footer } from "@/components/footer"
 import { HeaderWrapper } from "@/components/header-wrapper"
 import { LicenseNotice } from "@/components/license-notice"
 import { PostHogProvider } from "@/components/PostHogProvider"
+import { JsonLd } from "@/components/seo/json-ld"
 import { getDescription, WEB_URL, websiteTitle } from "@/constants"
 import { getTotalIcons } from "@/lib/api"
+import { buildDefaultOgImages, buildDefaultTwitterImages } from "@/lib/seo/metadata"
+import { buildOrganizationGraph } from "@/lib/seo/schemas"
 import "./globals.css"
 import { Providers } from "@/components/providers"
 import { ThemeProvider } from "./theme-provider"
@@ -60,21 +63,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: websiteTitle,
 			url: WEB_URL,
 			description: getDescription(totalIcons),
-			images: [
-				{
-					url: "/og-image.png",
-					width: 1200,
-					height: 630,
-					alt: "Dashboard Icons - Free icons and logos for self-hosted services",
-					type: "image/png",
-				},
-			],
+			images: buildDefaultOgImages("Dashboard Icons - Free icons and logos for self-hosted services"),
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: websiteTitle,
 			description: getDescription(totalIcons),
-			images: ["/og-image.png"],
+			images: buildDefaultTwitterImages(),
 		},
 		applicationName: "Dashboard Icons",
 		alternates: {
@@ -87,13 +82,8 @@ export async function generateMetadata(): Promise<Metadata> {
 			capable: true,
 		},
 		icons: {
-			icon: [
-				{ url: "/favicon.ico", sizes: "any" },
-				{ url: "/favicon-96x96.png", sizes: "96x96", type: "image/png" },
-				{ url: "/web-app-manifest-192x192.png", sizes: "192x192", type: "image/png" },
-				{ url: "/web-app-manifest-512x512.png", sizes: "512x512", type: "image/png" },
-			],
-			apple: [{ url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" }],
+			icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
+			apple: [{ url: "/favicon.svg", type: "image/svg+xml" }],
 		},
 		manifest: "/site.webmanifest",
 		formatDetection: {
@@ -111,6 +101,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 				<link rel="preconnect" href="https://cdn.jsdelivr.net" />
 				<link rel="preconnect" href="https://raw.githubusercontent.com" />
 				<link rel="preconnect" href="https://api.github.com" />
+				<link rel="alternate" type="text/plain" href="/llms.txt" />
 				{process.env.NEXT_PUBLIC_POSTHOG_HOST && (
 					<link
 						rel="preconnect"
@@ -125,26 +116,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 				)}
 			</head>
 			<body className={`${inter.variable} antialiased bg-background flex flex-col min-h-screen`}>
-				<script
-					type="application/ld+json"
-					// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-					dangerouslySetInnerHTML={{
-						__html: JSON.stringify({
-							"@context": "https://schema.org",
-							"@type": "WebSite",
-							name: "Dashboard Icons",
-							url: WEB_URL,
-							potentialAction: {
-								"@type": "SearchAction",
-								target: {
-									"@type": "EntryPoint",
-									urlTemplate: `${WEB_URL}/icons?search={search_term_string}`,
-								},
-								"query-input": "required name=search_term_string",
-							},
-						}).replace(/</g, "\\u003c"),
-					}}
-				/>
+				<JsonLd data={buildOrganizationGraph()} />
 				<Providers>
 					<PostHogProvider>
 						<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>

--- a/web/src/app/license/page.tsx
+++ b/web/src/app/license/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { REPO_PATH, WEB_URL } from "@/constants"
+
+export const metadata: Metadata = {
+	title: "License & Trademark Policy",
+	description:
+		"License terms for Dashboard Icons native collection (CC BY 4.0), trademark disclaimer, and attribution requirements.",
+	alternates: {
+		canonical: `${WEB_URL}/license`,
+	},
+	openGraph: {
+		title: "License & Trademark Policy",
+		description: "License terms and trademark disclaimer for Dashboard Icons.",
+		url: `${WEB_URL}/license`,
+		type: "website",
+	},
+}
+
+export default function LicensePage() {
+	return (
+		<div className="container mx-auto px-4 md:px-6 py-12 max-w-3xl">
+			<h1 className="text-3xl font-bold mb-6">License & trademark policy</h1>
+
+			<section className="flex flex-col gap-4 text-muted-foreground leading-relaxed">
+				<h2 className="text-xl font-semibold text-foreground">Native Dashboard Icons license</h2>
+				<p>
+					Icons in the native Dashboard Icons collection are licensed under{" "}
+					<Link href="https://creativecommons.org/licenses/by/4.0/" className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+						Creative Commons Attribution 4.0 International (CC BY 4.0)
+					</Link>
+					. You may download, share, and adapt these icons for free with appropriate attribution.
+				</p>
+				<p>
+					View the full project license on GitHub:{" "}
+					<Link href={`${REPO_PATH}/blob/main/LICENSE`} className="underline hover:text-foreground" target="_blank" rel="noopener noreferrer">
+						{REPO_PATH}/blob/main/LICENSE
+					</Link>
+				</p>
+
+				<h2 className="text-xl font-semibold text-foreground mt-4">External icon sources</h2>
+				<p>
+					Some icons are sourced from third-party collections such as selfh.st and LobeHub. Those icons retain their original licenses (CC BY 4.0 or MIT). Check each icon detail page for the applicable license.
+				</p>
+
+				<h2 className="text-xl font-semibold text-foreground mt-4">Trademark disclaimer</h2>
+				<p>
+					All product names, trademarks, and registered trademarks are the property of their respective owners. Icons are used for identification purposes only and do not imply endorsement by the trademark holder.
+				</p>
+
+				<h2 className="text-xl font-semibold text-foreground mt-4">Contact</h2>
+				<p>
+					Questions about licensing:{" "}
+					<Link href="mailto:homarr-labs@proton.me" className="underline hover:text-foreground">
+						homarr-labs@proton.me
+					</Link>
+				</p>
+			</section>
+		</div>
+	)
+}

--- a/web/src/app/og/__tests__/default-route.test.ts
+++ b/web/src/app/og/__tests__/default-route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest"
+
+const mockImageResponse = vi.fn()
+
+class MockImageResponse {
+	constructor(...args: unknown[]) {
+		mockImageResponse(...args)
+	}
+}
+
+vi.mock("next/og", () => ({
+	ImageResponse: MockImageResponse,
+}))
+
+vi.mock("@/lib/api", () => ({
+	getTotalIcons: vi.fn(() => Promise.resolve({ totalIcons: 1234 })),
+}))
+
+vi.mock("@/constants", () => ({
+	DASHBOARD_ICONS_ICON: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/dashboard-icons.svg",
+}))
+
+describe("OG default route handler", () => {
+	it("exports correct content type and size", async () => {
+		const mod = await import("../default/route")
+		expect(mod.contentType).toBe("image/png")
+		expect(mod.size).toEqual({ width: 1200, height: 630 })
+	})
+
+	it("returns ImageResponse with noindex header", async () => {
+		mockImageResponse.mockClear()
+		const { GET } = await import("../default/route")
+		await GET(new Request("http://localhost/og/default"))
+
+		expect(mockImageResponse).toHaveBeenCalledTimes(1)
+		const options = mockImageResponse.mock.calls[0][1] as { headers: Record<string, string> }
+		expect(options.headers["X-Robots-Tag"]).toBe("noindex")
+	})
+})

--- a/web/src/app/og/community/[icon]/route.tsx
+++ b/web/src/app/og/community/[icon]/route.tsx
@@ -1,0 +1,126 @@
+import { notFound } from "next/navigation"
+import { ImageResponse } from "next/og"
+import { BASE_URL, DASHBOARD_ICONS_ICON } from "@/constants"
+import { getCommunitySubmissionByName } from "@/lib/community"
+
+export const contentType = "image/png"
+export const size = { width: 1200, height: 630 }
+
+function resolveCommunityIconUrl(iconName: string, iconData: Awaited<ReturnType<typeof getCommunitySubmissionByName>>) {
+	if (!iconData) return null
+
+	const directBase = iconData.data.base
+	if (typeof directBase === "string" && directBase.startsWith("http")) {
+		return directBase
+	}
+
+	const mainIconUrl = (iconData.data as { mainIconUrl?: string }).mainIconUrl
+	if (mainIconUrl) {
+		return mainIconUrl
+	}
+
+	return `${BASE_URL}/svg/${iconName}.svg`
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ icon: string }> }) {
+	const { icon } = await params
+	const iconData = await getCommunitySubmissionByName(icon)
+
+	if (!iconData) {
+		notFound()
+	}
+
+	const iconUrl = resolveCommunityIconUrl(icon, iconData)
+	if (!iconUrl) {
+		notFound()
+	}
+
+	const formattedName = icon
+		.split("-")
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ")
+
+	return new ImageResponse(
+		<div
+			style={{
+				display: "flex",
+				width: "100%",
+				height: "100%",
+				position: "relative",
+				fontFamily: "system-ui, sans-serif",
+				overflow: "hidden",
+				backgroundColor: "white",
+				backgroundImage:
+					"radial-gradient(circle at 25px 25px, lightgray 2%, transparent 0%), radial-gradient(circle at 75px 75px, lightgray 2%, transparent 0%)",
+				backgroundSize: "100px 100px",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					alignItems: "center",
+					justifyContent: "center",
+					width: "100%",
+					height: "100%",
+					padding: "60px",
+					gap: "70px",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						width: 320,
+						height: 320,
+						borderRadius: 32,
+						background: "white",
+						boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.05)",
+						padding: 30,
+						flexShrink: 0,
+					}}
+				>
+					{/* biome-ignore lint/performance/noImgElement: ImageResponse uses Satori which requires native HTML img elements */}
+					<img src={iconUrl} alt={formattedName} width={260} height={260} style={{ objectFit: "contain" }} />
+				</div>
+				<div style={{ display: "flex", flexDirection: "column", gap: 24, maxWidth: 650 }}>
+					<div style={{ display: "flex", fontSize: 56, fontWeight: 800, color: "#0f172a", lineHeight: 1.1 }}>
+						{formattedName} community icon
+					</div>
+					<div style={{ display: "flex", fontSize: 28, fontWeight: 500, color: "#64748b", paddingLeft: 16, borderLeft: "4px solid #94a3b8" }}>
+						Community submission on DashboardIcons.com
+					</div>
+				</div>
+			</div>
+			<div
+				style={{
+					position: "absolute",
+					bottom: 0,
+					left: 0,
+					right: 0,
+					height: 80,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					background: "#ffffff",
+					borderTop: "2px solid rgba(0, 0, 0, 0.05)",
+				}}
+			>
+				<div style={{ display: "flex", fontSize: 24, fontWeight: 600, color: "#334155", alignItems: "center", gap: 10 }}>
+					{/* biome-ignore lint/performance/noImgElement: ImageResponse uses Satori which requires native HTML img elements */}
+					<img src={DASHBOARD_ICONS_ICON} alt="dashboardicons.com" width={32} height={32} />
+					dashboardicons.com
+				</div>
+			</div>
+		</div>,
+		{
+			...size,
+			headers: {
+				"Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+				"CDN-Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
+				"X-Robots-Tag": "noindex",
+			},
+		},
+	)
+}

--- a/web/src/app/og/default/route.tsx
+++ b/web/src/app/og/default/route.tsx
@@ -1,0 +1,168 @@
+import { ImageResponse } from "next/og"
+import { DASHBOARD_ICONS_ICON } from "@/constants"
+import { getTotalIcons } from "@/lib/api"
+
+export const contentType = "image/png"
+export const size = { width: 1200, height: 630 }
+
+export async function GET() {
+	const { totalIcons } = await getTotalIcons()
+
+	return new ImageResponse(
+		<div
+			style={{
+				display: "flex",
+				width: "100%",
+				height: "100%",
+				position: "relative",
+				fontFamily: "system-ui, sans-serif",
+				overflow: "hidden",
+				backgroundColor: "white",
+				backgroundImage:
+					"radial-gradient(circle at 25px 25px, lightgray 2%, transparent 0%), radial-gradient(circle at 75px 75px, lightgray 2%, transparent 0%)",
+				backgroundSize: "100px 100px",
+			}}
+		>
+			<div
+				style={{
+					position: "absolute",
+					top: -100,
+					left: -100,
+					width: 400,
+					height: 400,
+					borderRadius: "50%",
+					background: "linear-gradient(135deg, rgba(56, 189, 248, 0.1) 0%, rgba(59, 130, 246, 0.1) 100%)",
+					filter: "blur(80px)",
+				}}
+			/>
+			<div
+				style={{
+					position: "absolute",
+					bottom: -150,
+					right: -150,
+					width: 500,
+					height: 500,
+					borderRadius: "50%",
+					background: "linear-gradient(135deg, rgba(249, 115, 22, 0.1) 0%, rgba(234, 88, 12, 0.1) 100%)",
+					filter: "blur(100px)",
+				}}
+			/>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					alignItems: "center",
+					justifyContent: "center",
+					width: "100%",
+					height: "100%",
+					padding: "60px",
+					gap: "70px",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						width: 320,
+						height: 320,
+						borderRadius: 32,
+						background: "white",
+						boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.05)",
+						padding: 30,
+						flexShrink: 0,
+						position: "relative",
+						overflow: "hidden",
+					}}
+				>
+					{/* biome-ignore lint/performance/noImgElement: ImageResponse uses Satori which requires native HTML img elements */}
+					<img src={DASHBOARD_ICONS_ICON} alt="Dashboard Icons" width={260} height={260} style={{ objectFit: "contain" }} />
+				</div>
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						justifyContent: "center",
+						gap: 28,
+						maxWidth: 650,
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							fontSize: 64,
+							fontWeight: 800,
+							color: "#0f172a",
+							lineHeight: 1.1,
+							letterSpacing: "-0.02em",
+						}}
+					>
+						Free dashboard icons & logos
+					</div>
+					<div
+						style={{
+							display: "flex",
+							fontSize: 32,
+							fontWeight: 500,
+							color: "#64748b",
+							lineHeight: 1.4,
+							paddingLeft: 16,
+							borderLeft: "4px solid #94a3b8",
+						}}
+					>
+						{totalIcons} curated icons for dashboards and app directories
+					</div>
+					<div style={{ display: "flex", gap: 12, marginTop: 8 }}>
+						{["SVG", "PNG", "WEBP"].map((format) => (
+							<div
+								key={format}
+								style={{
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+									backgroundColor: "#f1f5f9",
+									color: "#475569",
+									border: "2px solid #e2e8f0",
+									borderRadius: 12,
+									padding: "8px 16px",
+									fontSize: 18,
+									fontWeight: 600,
+								}}
+							>
+								{format}
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+			<div
+				style={{
+					position: "absolute",
+					bottom: 0,
+					left: 0,
+					right: 0,
+					height: 80,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					background: "#ffffff",
+					borderTop: "2px solid rgba(0, 0, 0, 0.05)",
+				}}
+			>
+				<div style={{ display: "flex", fontSize: 24, fontWeight: 600, color: "#334155", alignItems: "center", gap: 10 }}>
+					{/* biome-ignore lint/performance/noImgElement: ImageResponse uses Satori which requires native HTML img elements */}
+					<img src={DASHBOARD_ICONS_ICON} alt="dashboardicons.com" width={32} height={32} />
+					dashboardicons.com
+				</div>
+			</div>
+		</div>,
+		{
+			...size,
+			headers: {
+				"Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+				"CDN-Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
+				"X-Robots-Tag": "noindex",
+			},
+		},
+	)
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,7 +1,10 @@
+import { HomeFaq } from "@/components/home-faq"
 import { HeroSection } from "@/components/hero"
 import { RecentlyAddedIcons } from "@/components/recently-added-icons"
-import { REPO_NAME, WEB_URL } from "@/constants"
+import { JsonLd } from "@/components/seo/json-ld"
+import { REPO_NAME, getDescription } from "@/constants"
 import { getRecentlyAddedIcons, getTotalIcons } from "@/lib/api"
+import { buildHomePageGraph } from "@/lib/seo/schemas"
 
 async function getGitHubStars() {
 	try {
@@ -20,46 +23,11 @@ export default async function Home() {
 	const iconStats = await getTotalIcons()
 	const recentIcons = await getRecentlyAddedIcons(20)
 	const stars = await getGitHubStars()
-
-	const websiteJsonLd = {
-		"@context": "https://schema.org",
-		"@type": "WebSite",
-		name: "Dashboard Icons",
-		url: WEB_URL,
-		description: `A collection of ${iconStats.totalIcons} curated icons and logos for services, applications and tools, designed specifically for dashboards and app directories.`,
-		inLanguage: "en",
-		publisher: {
-			"@type": "Organization",
-			name: "Homarr Labs",
-		},
-	}
-
-	const organizationJsonLd = {
-		"@context": "https://schema.org",
-		"@type": "Organization",
-		name: "Homarr Labs",
-		url: WEB_URL,
-		logo: {
-			"@type": "ImageObject",
-			url: `${WEB_URL}/og-image.png`,
-			width: 1200,
-			height: 630,
-		},
-		sameAs: [`https://github.com/${REPO_NAME}`],
-	}
+	const description = getDescription(iconStats.totalIcons)
 
 	return (
 		<>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd).replace(/</g, "\\u003c") }}
-			/>
-			<script
-				type="application/ld+json"
-				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd).replace(/</g, "\\u003c") }}
-			/>
+			<JsonLd data={buildHomePageGraph({ totalIcons: iconStats.totalIcons, description })} />
 			<div className="flex flex-col min-h-screen">
 				<HeroSection
 					totalIcons={iconStats.totalIcons}
@@ -68,6 +36,7 @@ export default async function Home() {
 					stars={stars}
 				/>
 				<RecentlyAddedIcons icons={recentIcons} />
+				<HomeFaq />
 			</div>
 		</>
 	)

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,15 +1,21 @@
 import type { MetadataRoute } from "next"
 import { WEB_URL } from "@/constants"
 
+const AI_CRAWLERS = ["GPTBot", "ClaudeBot", "PerplexityBot", "Google-Extended"] as const
+
+const DISALLOWED_PATHS = ["/api/", "/dashboard/", "/submit/", "/og/"]
+
+function buildCrawlerRule(userAgent: string) {
+	return {
+		userAgent,
+		allow: "/",
+		disallow: DISALLOWED_PATHS,
+	}
+}
+
 export default function robots(): MetadataRoute.Robots {
 	return {
-		rules: [
-			{
-				userAgent: "*",
-				allow: "/",
-				disallow: ["/api/", "/dashboard/", "/submit/", "/og/"],
-			},
-		],
+		rules: [buildCrawlerRule("*"), ...AI_CRAWLERS.map((crawler) => buildCrawlerRule(crawler))],
 		sitemap: `${WEB_URL}/sitemap.xml`,
 	}
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -27,7 +27,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			lastModified: formatDate(new Date()),
 			changeFrequency: "daily",
 			priority: 1,
-			images: [`${WEB_URL}/icons/icon.png`],
+			images: [`${WEB_URL}/og/default`],
+		},
+		{
+			url: `${WEB_URL}/license`,
+			lastModified: formatDate(new Date()),
+			changeFrequency: "yearly",
+			priority: 0.5,
 		},
 		{
 			url: `${WEB_URL}/community`,

--- a/web/src/app/submit/layout.tsx
+++ b/web/src/app/submit/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import type React from "react"
+import { WEB_URL } from "@/constants"
 import { cn } from "@/lib/utils"
 
 export const metadata: Metadata = {
@@ -7,8 +8,11 @@ export const metadata: Metadata = {
 	description:
 		"Submit your icons and logos to the Dashboard Icons collection. Share your designs with the community and help expand the collection.",
 	robots: {
-		index: true,
+		index: false,
 		follow: true,
+	},
+	alternates: {
+		canonical: `${WEB_URL}/submit`,
 	},
 }
 

--- a/web/src/components/home-faq.tsx
+++ b/web/src/components/home-faq.tsx
@@ -1,0 +1,17 @@
+import { HOME_FAQS } from "@/lib/seo/faqs"
+
+export function HomeFaq() {
+	return (
+		<section className="container mx-auto px-4 md:px-6 py-16 max-w-3xl">
+			<h2 className="text-2xl font-bold mb-8">Frequently asked questions</h2>
+			<div className="flex flex-col gap-8">
+				{HOME_FAQS.map((faq) => (
+					<div key={faq.question}>
+						<h3 className="text-lg font-semibold mb-2">{faq.question}</h3>
+						<p className="text-muted-foreground leading-relaxed">{faq.answer}</p>
+					</div>
+				))}
+			</div>
+		</section>
+	)
+}

--- a/web/src/components/icon-details.tsx
+++ b/web/src/components/icon-details.tsx
@@ -812,9 +812,10 @@ export function IconDetails({
 										/>
 									</div>
 								</div>
-								<CardTitle className="text-2xl font-bold capitalize text-center mb-2">
-									<h1>{formatedIconName}</h1>
-								</CardTitle>
+								<h1 className="text-2xl font-bold capitalize text-center mb-2">{formatedIconName}</h1>
+								<p className="text-sm text-muted-foreground text-center max-w-md">
+									Download the {formatedIconName} icon in SVG, PNG, and WEBP formats for free.
+								</p>
 							</div>
 						</CardHeader>
 						<CardContent>

--- a/web/src/components/seo/json-ld.tsx
+++ b/web/src/components/seo/json-ld.tsx
@@ -1,0 +1,15 @@
+type JsonLdProps = {
+	data: Record<string, unknown>
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+	return (
+		<script
+			type="application/ld+json"
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data
+			dangerouslySetInnerHTML={{
+				__html: JSON.stringify(data).replace(/</g, "\\u003c"),
+			}}
+		/>
+	)
+}

--- a/web/src/lib/seo/faqs.ts
+++ b/web/src/lib/seo/faqs.ts
@@ -1,0 +1,37 @@
+export type FaqItem = {
+	question: string
+	answer: string
+}
+
+export const HOME_FAQS: FaqItem[] = [
+	{
+		question: "What is Dashboard Icons?",
+		answer:
+			"Dashboard Icons is a free collection of curated icons and logos for self-hosted services, applications, and tools. It is designed for dashboards, app directories, and homelab setups.",
+	},
+	{
+		question: "What formats are available?",
+		answer:
+			"Each icon is available in SVG, PNG, and WEBP formats. SVG files are ideal for scaling, while PNG and WEBP work well in dashboards and app launchers.",
+	},
+	{
+		question: "Are icons free to use?",
+		answer:
+			"Native Dashboard Icons are licensed under Creative Commons Attribution 4.0 (CC BY 4.0). You can download and use them for free with attribution. External icon sets may use different licenses.",
+	},
+	{
+		question: "How do I search for an icon?",
+		answer:
+			"Use the search bar on the homepage or browse page at /icons. Search by service name or alias, then filter by source or sort results.",
+	},
+	{
+		question: "How can I contribute?",
+		answer:
+			"You can submit new icons through the submit page or contribute directly on GitHub at github.com/homarr-labs/dashboard-icons.",
+	},
+	{
+		question: "Who maintains Dashboard Icons?",
+		answer:
+			"Dashboard Icons is maintained by Homarr Labs. The project is open source and community contributions are welcome.",
+	},
+]

--- a/web/src/lib/seo/metadata.ts
+++ b/web/src/lib/seo/metadata.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from "next"
+import { WEB_URL } from "@/constants"
+
+export const DEFAULT_OG_PATH = "/og/default"
+
+const FILTER_PARAMS = ["q", "sort", "source", "category"] as const
+
+export function buildDefaultOgImages(alt: string) {
+	return [
+		{
+			url: DEFAULT_OG_PATH,
+			width: 1200,
+			height: 630,
+			alt,
+			type: "image/png",
+		},
+	]
+}
+
+export function buildDefaultTwitterImages() {
+	return [DEFAULT_OG_PATH]
+}
+
+export function getFilteredBrowseMetadata(
+	searchParams: Record<string, string | string[] | undefined>,
+	basePath: "/icons" | "/community",
+): Pick<Metadata, "robots" | "alternates"> {
+	const hasFilters = FILTER_PARAMS.some((param) => searchParams[param])
+
+	const filteredMetadata: Pick<Metadata, "robots" | "alternates"> = {
+		robots: { index: false, follow: true },
+		alternates: { canonical: `${WEB_URL}${basePath}` },
+	}
+
+	const defaultMetadata: Pick<Metadata, "robots" | "alternates"> = {
+		alternates: { canonical: `${WEB_URL}${basePath}` },
+	}
+
+	const metadataByFilterState: Record<"filtered" | "default", Pick<Metadata, "robots" | "alternates">> = {
+		filtered: filteredMetadata,
+		default: defaultMetadata,
+	}
+
+	return metadataByFilterState[hasFilters ? "filtered" : "default"]
+}

--- a/web/src/lib/seo/schemas.test.ts
+++ b/web/src/lib/seo/schemas.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { HOME_FAQS } from "@/lib/seo/faqs"
+import {
+	buildFaqSchema,
+	buildHomePageGraph,
+	buildIconPageGraph,
+	buildIconsBrowseGraph,
+	buildOrganizationGraph,
+	buildWebSiteSchema,
+	resolveLicenseKey,
+} from "@/lib/seo/schemas"
+
+describe("seo schemas", () => {
+	it("buildOrganizationGraph includes Organization type", () => {
+		const schema = buildOrganizationGraph()
+		expect(schema["@context"]).toBe("https://schema.org")
+		expect(schema["@graph"]).toHaveLength(1)
+		expect((schema["@graph"] as Record<string, unknown>[])[0]["@type"]).toBe("Organization")
+	})
+
+	it("buildWebSiteSchema uses q search param", () => {
+		const schema = buildWebSiteSchema({ description: "test" }) as Record<string, unknown>
+		const action = schema.potentialAction as Record<string, unknown>
+		const target = action.target as Record<string, unknown>
+		expect(target.urlTemplate).toBe("https://dashboardicons.com/icons?q={search_term_string}")
+	})
+
+	it("buildHomePageGraph combines website, webapp, and faq schemas", () => {
+		const schema = buildHomePageGraph({ totalIcons: 100, description: "test description" })
+		const graph = schema["@graph"] as Record<string, unknown>[]
+		const types = graph.map((entry) => entry["@type"])
+		expect(types).toEqual(["WebSite", "WebApplication", "FAQPage"])
+	})
+
+	it("buildFaqSchema mirrors visible FAQ content", () => {
+		const schema = buildFaqSchema(HOME_FAQS) as Record<string, unknown>
+		const entities = schema.mainEntity as Record<string, unknown>[]
+		expect(entities).toHaveLength(HOME_FAQS.length)
+		expect(entities[0].name).toBe(HOME_FAQS[0].question)
+	})
+
+	it("buildIconsBrowseGraph includes CollectionPage and SearchAction", () => {
+		const schema = buildIconsBrowseGraph({ description: "browse", totalItems: 50 })
+		const graph = schema["@graph"] as Record<string, unknown>[]
+		const types = graph.map((entry) => entry["@type"])
+		expect(types).toContain("CollectionPage")
+		expect(types).toContain("WebSite")
+	})
+
+	it("buildIconPageGraph includes WebPage, ImageObject, and BreadcrumbList", () => {
+		const schema = buildIconPageGraph({
+			pageUrl: "https://dashboardicons.com/icons/grafana",
+			pageName: "Grafana Icon & Logo",
+			pageDescription: "Download Grafana icon",
+			dateModified: "2024-01-01T00:00:00.000Z",
+			contentUrl: "https://cdn.example.com/grafana.png",
+			licenseKey: "CC BY 4.0",
+			formattedName: "Grafana",
+			creator: { type: "Person", name: "Contributor", url: "https://github.com/contributor" },
+			breadcrumbs: [
+				{ name: "Home", item: "https://dashboardicons.com" },
+				{ name: "Browse Icons", item: "https://dashboardicons.com/icons" },
+				{ name: "Grafana Icon", item: "https://dashboardicons.com/icons/grafana" },
+			],
+		})
+		const graph = schema["@graph"] as Record<string, unknown>[]
+		const types = graph.map((entry) => entry["@type"])
+		expect(types).toEqual(["WebPage", "ImageObject", "BreadcrumbList"])
+	})
+
+	it("resolveLicenseKey maps known licenses", () => {
+		expect(resolveLicenseKey("MIT")).toBe("MIT")
+		expect(resolveLicenseKey("CC BY 4.0")).toBe("CC BY 4.0")
+		expect(resolveLicenseKey("unknown")).toBe("CC BY 4.0")
+	})
+})

--- a/web/src/lib/seo/schemas.ts
+++ b/web/src/lib/seo/schemas.ts
@@ -1,0 +1,262 @@
+import { getDescription, REPO_NAME, WEB_URL } from "@/constants"
+import { HOME_FAQS, type FaqItem } from "@/lib/seo/faqs"
+
+const SCHEMA_CONTEXT = "https://schema.org"
+
+const LICENSE_URLS: Record<string, string> = {
+	MIT: "https://opensource.org/licenses/MIT",
+	"CC BY 4.0": "https://creativecommons.org/licenses/by/4.0/",
+}
+
+export type SchemaCreator = {
+	type: "Person" | "Organization"
+	name: string
+	url?: string
+}
+
+export type SchemaBreadcrumb = {
+	name: string
+	item: string
+}
+
+export type IconPageGraphInput = {
+	pageUrl: string
+	pageName: string
+	pageDescription: string
+	dateModified: string
+	contentUrl: string
+	licenseKey: keyof typeof LICENSE_URLS
+	formattedName: string
+	creator: SchemaCreator
+	creditText?: string
+	copyrightNotice?: string
+	breadcrumbs: SchemaBreadcrumb[]
+	encodingFormat?: string
+}
+
+function buildGraph(schemas: Record<string, unknown>[]) {
+	return {
+		"@context": SCHEMA_CONTEXT,
+		"@graph": schemas,
+	}
+}
+
+function buildListItems(breadcrumbs: SchemaBreadcrumb[]) {
+	return breadcrumbs.map((crumb, index) => ({
+		"@type": "ListItem",
+		position: index + 1,
+		name: crumb.name,
+		item: crumb.item,
+	}))
+}
+
+function buildCreatorSchema(creator: SchemaCreator) {
+	const creatorSchema: Record<string, unknown> = {
+		"@type": creator.type,
+		name: creator.name,
+	}
+
+	const urlFields: Record<string, string> = creator.url ? { url: creator.url } : {}
+
+	return { ...creatorSchema, ...urlFields }
+}
+
+function buildSearchAction() {
+	return {
+		"@type": "SearchAction",
+		target: {
+			"@type": "EntryPoint",
+			urlTemplate: `${WEB_URL}/icons?q={search_term_string}`,
+		},
+		"query-input": "required name=search_term_string",
+	}
+}
+
+export function buildOrganizationSchema() {
+	return {
+		"@type": "Organization",
+		name: "Homarr Labs",
+		url: WEB_URL,
+		logo: {
+			"@type": "ImageObject",
+			url: `${WEB_URL}/og/default`,
+			width: 1200,
+			height: 630,
+		},
+		sameAs: [`https://github.com/${REPO_NAME}`],
+	}
+}
+
+export function buildOrganizationGraph() {
+	return buildGraph([buildOrganizationSchema()])
+}
+
+export function buildWebSiteSchema({ description }: { description: string }) {
+	return {
+		"@type": "WebSite",
+		name: "Dashboard Icons",
+		url: WEB_URL,
+		description,
+		inLanguage: "en",
+		publisher: {
+			"@type": "Organization",
+			name: "Homarr Labs",
+		},
+		potentialAction: buildSearchAction(),
+	}
+}
+
+export function buildWebApplicationSchema({ totalIcons }: { totalIcons: number }) {
+	return {
+		"@type": "WebApplication",
+		name: "Dashboard Icons",
+		url: WEB_URL,
+		description: getDescription(totalIcons),
+		applicationCategory: "UtilityApplication",
+		operatingSystem: "Any",
+		offers: {
+			"@type": "Offer",
+			price: "0",
+			priceCurrency: "USD",
+		},
+		featureList: [
+			"Browse curated dashboard icons",
+			"Download SVG, PNG, and WEBP formats",
+			"Customize icon colors",
+			"Search by service name or alias",
+		],
+	}
+}
+
+export function buildFaqSchema(faqs: FaqItem[]) {
+	return {
+		"@type": "FAQPage",
+		mainEntity: faqs.map((faq) => ({
+			"@type": "Question",
+			name: faq.question,
+			acceptedAnswer: {
+				"@type": "Answer",
+				text: faq.answer,
+			},
+		})),
+	}
+}
+
+export function buildHomePageGraph({ totalIcons, description }: { totalIcons: number; description: string }) {
+	return buildGraph([buildWebSiteSchema({ description }), buildWebApplicationSchema({ totalIcons }), buildFaqSchema(HOME_FAQS)])
+}
+
+export function buildCollectionPageSchema({
+	url,
+	name,
+	description,
+	totalItems,
+}: {
+	url: string
+	name: string
+	description: string
+	totalItems: number
+}) {
+	return {
+		"@type": "CollectionPage",
+		name,
+		description,
+		url,
+		numberOfItems: totalItems,
+		isPartOf: {
+			"@type": "WebSite",
+			name: "Dashboard Icons",
+			url: WEB_URL,
+		},
+	}
+}
+
+export function buildIconsBrowseGraph({
+	description,
+	totalItems,
+}: {
+	description: string
+	totalItems: number
+}) {
+	return buildGraph([
+		buildCollectionPageSchema({
+			url: `${WEB_URL}/icons`,
+			name: "Browse Icons & Logos",
+			description,
+			totalItems,
+		}),
+		{
+			"@type": "WebSite",
+			name: "Dashboard Icons",
+			url: WEB_URL,
+			potentialAction: buildSearchAction(),
+		},
+	])
+}
+
+export function buildCommunityBrowseGraph({
+	description,
+	totalItems,
+}: {
+	description: string
+	totalItems: number
+}) {
+	return buildGraph([
+		buildCollectionPageSchema({
+			url: `${WEB_URL}/community`,
+			name: "Browse Community Icons & Logos",
+			description,
+			totalItems,
+		}),
+	])
+}
+
+export function buildIconPageGraph(input: IconPageGraphInput) {
+	const licenseUrl = LICENSE_URLS[input.licenseKey]
+	const imageObject: Record<string, unknown> = {
+		"@type": "ImageObject",
+		name: `${input.formattedName} Icon`,
+		description: input.pageDescription,
+		contentUrl: input.contentUrl,
+		license: licenseUrl,
+		acquireLicensePage: `${WEB_URL}/license`,
+		dateModified: input.dateModified,
+		creator: buildCreatorSchema(input.creator),
+	}
+
+	const optionalImageFields: Record<string, string> = {
+		...(input.creditText ? { creditText: input.creditText } : {}),
+		...(input.copyrightNotice ? { copyrightNotice: input.copyrightNotice } : {}),
+		...(input.encodingFormat ? { encodingFormat: input.encodingFormat } : {}),
+	}
+
+	return buildGraph([
+		{
+			"@type": "WebPage",
+			name: input.pageName,
+			description: input.pageDescription,
+			url: input.pageUrl,
+			dateModified: input.dateModified,
+			isPartOf: {
+				"@type": "WebSite",
+				name: "Dashboard Icons",
+				url: WEB_URL,
+			},
+			mainEntity: {
+				"@type": "ImageObject",
+				contentUrl: input.contentUrl,
+			},
+		},
+		{ ...imageObject, ...optionalImageFields },
+		{
+			"@type": "BreadcrumbList",
+			itemListElement: buildListItems(input.breadcrumbs),
+		},
+	])
+}
+
+export function resolveLicenseKey(licenseLabel: string): keyof typeof LICENSE_URLS {
+	const licenseKeys = Object.keys(LICENSE_URLS) as Array<keyof typeof LICENSE_URLS>
+	const matchedKey = licenseKeys.find((key) => key === licenseLabel)
+	return matchedKey ?? "CC BY 4.0"
+}


### PR DESCRIPTION
## Summary
- Centralize JSON-LD via shared schema builders and a reusable `JsonLd` component using Next.js `@graph` patterns
- Fix critical SEO bugs: SearchAction now uses `?q=`, add `/license` page, replace missing OG image with `/og/default`, and fix sitemap/manifest asset references
- Add AEO surfaces: homepage FAQ (visible + FAQPage schema), `llms.txt`, richer icon page structured data, and answer-first copy on icon details
- Align crawl policy: explicit AI crawler allow rules, filtered browse URL noindex/canonical, submit page noindex, community OG route

## Test plan
- [x] `pnpm test` (866 tests passing)
- [x] `pnpm build` succeeds
- [ ] Validate JSON-LD on `/`, `/icons`, `/icons/{slug}`, `/license` with Google Rich Results Test
- [ ] Confirm `/robots.txt`, `/sitemap.xml`, and `/llms.txt` are reachable after deploy
- [ ] Verify `/icons?q=docker` search works and filtered URLs are noindexed