### PR TITLE
fix: server-side caching to reduce PocketBase API calls

### DIFF
--- a/web/src/app/api/icons/search/route.ts
+++ b/web/src/app/api/icons/search/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import { unstable_cache } from "next/cache"
+import { getIconsArray } from "@/lib/api"
+import { getExternalIcons } from "@/lib/external-icons"
+import type { IconWithName } from "@/types/icons"
+
+const REVALIDATE_SECONDS = 900
+
+const getCachedIconList = unstable_cache(
+	async (): Promise<IconWithName[]> => {
+		const [native, external] = await Promise.all([getIconsArray(), getExternalIcons()])
+		return [...native, ...external]
+	},
+	["icons-search-list"],
+	{ revalidate: REVALIDATE_SECONDS, tags: ["icons-search"] },
+)
+
+export async function GET() {
+	const icons = await getCachedIconList()
+	return NextResponse.json(icons, {
+		headers: {
+			"Cache-Control": `public, s-maxage=${REVALIDATE_SECONDS}, stale-while-revalidate=${REVALIDATE_SECONDS * 2}`,
+		},
+	})
+}

--- a/web/src/app/community/[icon]/page.tsx
+++ b/web/src/app/community/[icon]/page.tsx
@@ -14,7 +14,7 @@ function isIconAddedToCollection(
 }
 
 export const dynamicParams = true
-export const revalidate = 21600 // 6 hours
+export const revalidate = 900
 export const dynamic = "force-static"
 
 export async function generateStaticParams() {

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { Suspense } from "react"
 import { CommunityIconSearch } from "@/components/community-icon-search"
 import { WEB_URL } from "@/constants"
-import { fetchCommunitySubmissions, getCommunitySubmissions } from "@/lib/community"
+import { getCommunitySubmissions } from "@/lib/community"
 
 export const revalidate = 300
 
@@ -43,7 +43,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function CommunityPage() {
-	const icons = await fetchCommunitySubmissions()
+	const icons = await getCommunitySubmissions()
 	return (
 		<div className="isolate overflow-hidden p-2 mx-auto max-w-7xl">
 			<div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -4,7 +4,7 @@ import { CommunityIconSearch } from "@/components/community-icon-search"
 import { WEB_URL } from "@/constants"
 import { getCommunitySubmissions } from "@/lib/community"
 
-export const revalidate = 300
+export const revalidate = 900
 
 export async function generateMetadata(): Promise<Metadata> {
 	const icons = await getCommunitySubmissions()

--- a/web/src/app/icons/page.tsx
+++ b/web/src/app/icons/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export const dynamic = "force-static"
-export const revalidate = 21600
+export const revalidate = 900
 
 export default async function IconsPage() {
 	const [nativeIcons, externalIcons] = await Promise.all([getIconsArray(), getExternalIcons()])

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 900
+
 import { HeroSection } from "@/components/hero"
 import { RecentlyAddedIcons } from "@/components/recently-added-icons"
 import { REPO_NAME, WEB_URL } from "@/constants"

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -5,7 +5,7 @@ import { getCommunitySubmissions } from "@/lib/community"
 import { resolveExternalIconUrl } from "@/lib/external-icon-urls"
 import { getExternalIcons } from "@/lib/external-icons"
 
-export const revalidate = 21600
+export const revalidate = 900
 
 // Helper function to format dates as YYYY-MM-DD
 const formatDate = (date: Date): string => {

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -8,8 +8,6 @@ import { useEffect, useState } from "react"
 import { LoginModal } from "@/components/login-modal"
 import { ThemeSwitcher } from "@/components/theme-switcher"
 import { REPO_NAME, REPO_PATH } from "@/constants"
-import { getIconsArray } from "@/lib/api"
-import { getExternalIcons } from "@/lib/external-icons"
 import { pb } from "@/lib/pb"
 import { resetPostHogIdentity } from "@/lib/posthog-utils"
 import type { IconWithName } from "@/types/icons"
@@ -48,8 +46,9 @@ export function Header() {
 	useEffect(() => {
 		async function loadIcons() {
 			try {
-				const [native, external] = await Promise.all([getIconsArray(), getExternalIcons()])
-				setIconsData([...native, ...external])
+				const response = await fetch("/api/icons/search")
+				const data = await response.json()
+				setIconsData(data)
 				setIsLoaded(true)
 			} catch (error) {
 				console.error("Failed to load icons:", error)

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -46,8 +46,10 @@ export function Header() {
 	useEffect(() => {
 		async function loadIcons() {
 			try {
-				const response = await fetch("/api/icons/search")
+				const response = await fetch("/api/icons/search", { credentials: "omit" })
+				if (!response.ok) throw new Error(`HTTP ${response.status}`)
 				const data = await response.json()
+				if (!Array.isArray(data)) throw new Error("Invalid response shape")
 				setIconsData(data)
 				setIsLoaded(true)
 			} catch (error) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -9,7 +9,9 @@ import type { AuthorData, Icon, IconFile, IconWithName, NativeIconRecord } from 
  */
 export async function getAllIcons(): Promise<IconFile> {
 	try {
-		const response = await fetch(METADATA_URL)
+		const response = await fetch(METADATA_URL, {
+			next: { revalidate: 900, tags: ["native-icons"] },
+		})
 
 		if (!response.ok) {
 			throw new ApiError(`Failed to fetch icons: ${response.statusText}`, response.status)

--- a/web/src/lib/community.ts
+++ b/web/src/lib/community.ts
@@ -123,11 +123,11 @@ export async function fetchCommunitySubmissions(): Promise<IconWithName[]> {
 /**
  * Cached version of fetchCommunitySubmissions
  * Uses unstable_cache with tags for on-demand revalidation
- * Revalidates every 21600 seconds (6 hours) to match page revalidate time
+ * Revalidates every 900 seconds (15 minutes)
  * Can be invalidated on-demand using revalidateTag("community-gallery")
  */
 export const getCommunitySubmissions = unstable_cache(fetchCommunitySubmissions, ["community-submissions-list-v2"], {
-	revalidate: 21600,
+	revalidate: 900,
 	tags: ["community-gallery"],
 })
 
@@ -151,12 +151,12 @@ async function fetchCommunitySubmissionByName(name: string): Promise<IconWithNam
 /**
  * Cached version of fetchCommunitySubmissionByName
  * Uses unstable_cache with tags for on-demand revalidation
- * Revalidates every 21600 seconds (6 hours)
+ * Revalidates every 900 seconds (15 minutes)
  * Cache key: community-submission-{name}
  */
 export function getCommunitySubmissionByName(name: string): Promise<IconWithName | null> {
 	return unstable_cache(async () => fetchCommunitySubmissionByName(name), [`community-submission-${name}-v2`], {
-		revalidate: 21600,
+		revalidate: 900,
 		tags: ["community-gallery", "community-submission"],
 	})()
 }
@@ -179,12 +179,12 @@ async function fetchCommunityGalleryRecord(name: string): Promise<CommunityGalle
 /**
  * Cached version of fetchCommunityGalleryRecord
  * Uses unstable_cache with tags for on-demand revalidation
- * Revalidates every 21600 seconds (6 hours)
+ * Revalidates every 900 seconds (15 minutes)
  * Cache key: community-gallery-record-{name}
  */
 export function getCommunityGalleryRecord(name: string): Promise<CommunityGallery | null> {
 	return unstable_cache(async () => fetchCommunityGalleryRecord(name), [`community-gallery-record-${name}`], {
-		revalidate: 21600,
+		revalidate: 900,
 		tags: ["community-gallery", "community-gallery-record"],
 	})()
 }

--- a/web/src/lib/external-icons.ts
+++ b/web/src/lib/external-icons.ts
@@ -4,7 +4,7 @@ import { createServerPB } from "@/lib/pb"
 import type { ExternalIcon, ExternalIconRecord, IconRecord, NativeIconRecord } from "@/types/icons"
 import { getIconsArray } from "./api"
 
-const EXTERNAL_REVALIDATE_SECONDS = 21600
+const EXTERNAL_REVALIDATE_SECONDS = 900
 const EXTERNAL_TTL_MS = EXTERNAL_REVALIDATE_SECONDS * 1000
 
 let _memCache: { data: ExternalIconRecord[]; ts: number } | null = null


### PR DESCRIPTION
## Summary

Addresses excessive PocketBase API calls observed in Cloudflare dashboard (`external_icons/records` at 111k, `community_gallery/records` high volume).

- **Fix community page uncached call**: `community/page.tsx` was calling the raw `fetchCommunitySubmissions()` instead of the `unstable_cache`-wrapped `getCommunitySubmissions()`, hitting PocketBase on every page visit
- **Add cached API route for header**: Created `/api/icons/search` with `unstable_cache` + `Cache-Control` headers so the header command menu fetches from a CDN-cacheable endpoint instead of making direct PocketBase SDK calls from the browser on every page load
- **Add explicit fetch revalidation**: `metadata.json` fetch in `api.ts` now has `next: { revalidate: 900, tags: ["native-icons"] }` instead of relying on implicit caching behavior
- **Reduce ISR intervals to 15 minutes**: All pages and data caches changed from 6h (21600s) to 15min (900s) for fresher content
- **Add ISR to home page**: Home page was rendering dynamically on every request; now uses `revalidate = 900`

## Test plan

- [ ] Verify `/icons` page loads correctly with ISR
- [ ] Verify `/community` page loads correctly with cached data
- [ ] Verify command menu (Cmd+K) still loads icons via `/api/icons/search`
- [ ] Verify home page renders with ISR (check response headers for cache status)
- [ ] Monitor Cloudflare dashboard for reduced PocketBase API call volume