### PR TITLE
feat(dashboard): add bulk reject for admin submissions

### DIFF
--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import {
 	useApproveSubmission,
 	useAuth,
 	useBulkApproveSubmissions,
+	useBulkRejectSubmissions,
 	useBulkTriggerWorkflow,
 	useRejectSubmission,
 	useSubmissions,
@@ -94,6 +95,7 @@ export default function DashboardPage() {
 	const workflowMutation = useTriggerWorkflow()
 	const bulkWorkflowMutation = useBulkTriggerWorkflow()
 	const bulkApproveMutation = useBulkApproveSubmissions()
+	const bulkRejectMutation = useBulkRejectSubmissions()
 
 	const [workflowUrl, setWorkflowUrl] = React.useState<string | undefined>()
 	const [approveDialogOpen, setApproveDialogOpen] = React.useState(false)
@@ -102,6 +104,9 @@ export default function DashboardPage() {
 	const [bulkApproveDialogOpen, setBulkApproveDialogOpen] = React.useState(false)
 	const [bulkApprovingIds, setBulkApprovingIds] = React.useState<string[]>([])
 	const [bulkApproveAdminComment, setBulkApproveAdminComment] = React.useState("")
+	const [bulkRejectDialogOpen, setBulkRejectDialogOpen] = React.useState(false)
+	const [bulkRejectingIds, setBulkRejectingIds] = React.useState<string[]>([])
+	const [bulkRejectAdminComment, setBulkRejectAdminComment] = React.useState("")
 	const [rejectDialogOpen, setRejectDialogOpen] = React.useState(false)
 	const [rejectingSubmissionId, setRejectingSubmissionId] = React.useState<string | null>(null)
 	const [adminComment, setAdminComment] = React.useState("")
@@ -206,6 +211,27 @@ export default function DashboardPage() {
 						setBulkApproveDialogOpen(false)
 						setBulkApprovingIds([])
 						setBulkApproveAdminComment("")
+					},
+				},
+			)
+		}
+	}
+
+	const handleBulkReject = (submissionIds: string[]) => {
+		setBulkRejectingIds(submissionIds)
+		setBulkRejectAdminComment("")
+		setBulkRejectDialogOpen(true)
+	}
+
+	const handleBulkRejectSubmit = () => {
+		if (bulkRejectingIds.length > 0) {
+			bulkRejectMutation.mutate(
+				{ submissionIds: [...bulkRejectingIds], adminComment: bulkRejectAdminComment.trim() || undefined },
+				{
+					onSuccess: () => {
+						setBulkRejectDialogOpen(false)
+						setBulkRejectingIds([])
+						setBulkRejectAdminComment("")
 					},
 				},
 			)
@@ -329,11 +355,13 @@ export default function DashboardPage() {
 										onTriggerWorkflow={handleTriggerWorkflow}
 										onBulkTriggerWorkflow={handleBulkTriggerWorkflow}
 										onBulkApprove={handleBulkApprove}
+										onBulkReject={handleBulkReject}
 										isApproving={approveMutation.isPending}
 										isRejecting={rejectMutation.isPending}
 										isTriggeringWorkflow={workflowMutation.isPending}
 										isBulkTriggeringWorkflow={bulkWorkflowMutation.isPending}
 										isBulkApproving={bulkApproveMutation.isPending}
+										isBulkRejecting={bulkRejectMutation.isPending}
 										workflowUrl={workflowUrl}
 										hideStatusHints
 									/>
@@ -353,11 +381,13 @@ export default function DashboardPage() {
 										onTriggerWorkflow={handleTriggerWorkflow}
 										onBulkTriggerWorkflow={handleBulkTriggerWorkflow}
 										onBulkApprove={handleBulkApprove}
+										onBulkReject={handleBulkReject}
 										isApproving={approveMutation.isPending}
 										isRejecting={rejectMutation.isPending}
 										isTriggeringWorkflow={workflowMutation.isPending}
 										isBulkTriggeringWorkflow={bulkWorkflowMutation.isPending}
 										isBulkApproving={bulkApproveMutation.isPending}
+										isBulkRejecting={bulkRejectMutation.isPending}
 										workflowUrl={workflowUrl}
 										hideStatusHints
 									/>
@@ -377,11 +407,13 @@ export default function DashboardPage() {
 										onTriggerWorkflow={handleTriggerWorkflow}
 										onBulkTriggerWorkflow={handleBulkTriggerWorkflow}
 										onBulkApprove={handleBulkApprove}
+										onBulkReject={handleBulkReject}
 										isApproving={approveMutation.isPending}
 										isRejecting={rejectMutation.isPending}
 										isTriggeringWorkflow={workflowMutation.isPending}
 										isBulkTriggeringWorkflow={bulkWorkflowMutation.isPending}
 										isBulkApproving={bulkApproveMutation.isPending}
+										isBulkRejecting={bulkRejectMutation.isPending}
 										workflowUrl={workflowUrl}
 									/>
 								)}
@@ -429,6 +461,20 @@ export default function DashboardPage() {
 					onCommentChange={setBulkApproveAdminComment}
 					onSubmit={handleBulkApproveSubmit}
 					isPending={bulkApproveMutation.isPending}
+				/>
+				<BulkRejectDialog
+					isMobile={isMobile}
+					open={bulkRejectDialogOpen}
+					onClose={() => {
+						setBulkRejectDialogOpen(false)
+						setBulkRejectingIds([])
+						setBulkRejectAdminComment("")
+					}}
+					count={bulkRejectingIds.length}
+					comment={bulkRejectAdminComment}
+					onCommentChange={setBulkRejectAdminComment}
+					onSubmit={handleBulkRejectSubmit}
+					isPending={bulkRejectMutation.isPending}
 				/>
 			</>
 		)
@@ -747,6 +793,90 @@ function BulkApproveDialog({
 					</Button>
 					<Button onClick={onSubmit} disabled={isPending}>
 						{isPending ? "Approving..." : label}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}
+
+function BulkRejectDialog({
+	isMobile,
+	open,
+	onClose,
+	count,
+	comment,
+	onCommentChange,
+	onSubmit,
+	isPending,
+}: {
+	isMobile: boolean
+	open: boolean
+	onClose: () => void
+	count: number
+	comment: string
+	onCommentChange: (v: string) => void
+	onSubmit: () => void
+	isPending: boolean
+}) {
+	const label = `Reject ${count} Submission${count > 1 ? "s" : ""}`
+
+	if (isMobile) {
+		return (
+			<Drawer open={open} onOpenChange={(o) => !o && onClose()}>
+				<DrawerContent>
+					<DrawerHeader className="text-left">
+						<DrawerTitle>{label}</DrawerTitle>
+						<DrawerDescription>All submitters will see the rejection reason.</DrawerDescription>
+					</DrawerHeader>
+					<div className="px-4 pb-2 space-y-2">
+						<Label htmlFor="bulk-reject-comment">Reason</Label>
+						<Textarea
+							id="bulk-reject-comment"
+							placeholder="e.g. Icons don't meet quality guidelines..."
+							value={comment}
+							onChange={(e) => onCommentChange(e.target.value)}
+							rows={3}
+						/>
+					</div>
+					<DrawerFooter>
+						<Button variant="destructive" onClick={onSubmit} disabled={isPending}>
+							{isPending ? "Rejecting..." : label}
+						</Button>
+						<DrawerClose asChild>
+							<Button variant="outline" disabled={isPending}>
+								Cancel
+							</Button>
+						</DrawerClose>
+					</DrawerFooter>
+				</DrawerContent>
+			</Drawer>
+		)
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{label}</DialogTitle>
+					<DialogDescription>All submitters will see the rejection reason.</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-2 py-4">
+					<Label htmlFor="bulk-reject-comment">Reason</Label>
+					<Textarea
+						id="bulk-reject-comment"
+						placeholder="e.g. Icons don't meet quality guidelines..."
+						value={comment}
+						onChange={(e) => onCommentChange(e.target.value)}
+						rows={3}
+					/>
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={onClose} disabled={isPending}>
+						Cancel
+					</Button>
+					<Button variant="destructive" onClick={onSubmit} disabled={isPending}>
+						{isPending ? "Rejecting..." : label}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/web/src/components/submissions-data-table.tsx
+++ b/web/src/components/submissions-data-table.tsx
@@ -15,7 +15,7 @@ import {
 } from "@tanstack/react-table"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
-import { CheckCircle2, ChevronDown, ChevronRight, Filter, Github, ImageIcon, Rocket, Search, SortDesc, X } from "lucide-react"
+import { CheckCircle2, ChevronDown, ChevronRight, Filter, Github, ImageIcon, Rocket, Search, SortDesc, X, XCircle } from "lucide-react"
 import * as React from "react"
 import { StatusBadge } from "@/components/status-badge"
 import { SubmissionDetails } from "@/components/submission-details"
@@ -62,11 +62,13 @@ interface SubmissionsDataTableProps {
 	onTriggerWorkflow?: (id: string) => void
 	onBulkTriggerWorkflow?: (ids: string[]) => void
 	onBulkApprove?: (ids: string[]) => void
+	onBulkReject?: (ids: string[]) => void
 	isApproving?: boolean
 	isRejecting?: boolean
 	isTriggeringWorkflow?: boolean
 	isBulkTriggeringWorkflow?: boolean
 	isBulkApproving?: boolean
+	isBulkRejecting?: boolean
 	workflowUrl?: string
 	hideStatusHints?: boolean
 }
@@ -96,11 +98,13 @@ export function SubmissionsDataTable({
 	onTriggerWorkflow,
 	onBulkTriggerWorkflow,
 	onBulkApprove,
+	onBulkReject,
 	isApproving,
 	isRejecting,
 	isTriggeringWorkflow,
 	isBulkTriggeringWorkflow,
 	isBulkApproving,
+	isBulkRejecting,
 	workflowUrl,
 	hideStatusHints,
 }: SubmissionsDataTableProps) {
@@ -400,7 +404,19 @@ export function SubmissionsDataTable({
 	const handleBulkApprove = () => {
 		if (onBulkApprove && selectedPendingIds.length > 0) {
 			onBulkApprove(selectedPendingIds)
-			// Only clear pending selections
+			setRowSelection(() => {
+				const next: RowSelectionState = {}
+				for (const id of selectedApprovedIds) {
+					next[id] = true
+				}
+				return next
+			})
+		}
+	}
+
+	const handleBulkReject = () => {
+		if (onBulkReject && selectedPendingIds.length > 0) {
+			onBulkReject(selectedPendingIds)
 			setRowSelection(() => {
 				const next: RowSelectionState = {}
 				for (const id of selectedApprovedIds) {
@@ -501,6 +517,18 @@ export function SubmissionsDataTable({
 						<Button variant="ghost" size="sm" onClick={() => setRowSelection({})} className="flex-1 sm:flex-none">
 							Clear selection
 						</Button>
+						{selectedPendingIds.length > 0 && onBulkReject && (
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={handleBulkReject}
+								disabled={isBulkRejecting}
+								className="flex-1 sm:flex-none border-red-500/30 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+							>
+								<XCircle className="w-4 h-4 mr-2" />
+								{isBulkRejecting ? "Rejecting..." : `Reject (${selectedPendingIds.length})`}
+							</Button>
+						)}
 						{selectedPendingIds.length > 0 && onBulkApprove && (
 							<Button
 								size="sm"

--- a/web/src/hooks/use-submissions.ts
+++ b/web/src/hooks/use-submissions.ts
@@ -110,6 +110,51 @@ export function useBulkApproveSubmissions() {
 	})
 }
 
+export function useBulkRejectSubmissions() {
+	const queryClient = useQueryClient()
+
+	return useMutation({
+		mutationFn: async ({ submissionIds, adminComment }: { submissionIds: string[]; adminComment?: string }) => {
+			const results = await Promise.allSettled(
+				submissionIds.map((submissionId) =>
+					pb.collection("submissions").update(
+						submissionId,
+						{
+							status: "rejected",
+							approved_by: pb.authStore.record?.id || "",
+							admin_comment: adminComment || "",
+						},
+						{ requestKey: null },
+					),
+				),
+			)
+			const fulfilled = results.filter((r) => r.status === "fulfilled")
+			const rejected = results.filter((r) => r.status === "rejected")
+			if (rejected.length > 0 && fulfilled.length === 0) {
+				throw new Error(`All ${rejected.length} rejections failed`)
+			}
+			return { fulfilled: fulfilled.length, rejected: rejected.length, total: results.length }
+		},
+		onSuccess: async (data) => {
+			queryClient.invalidateQueries({ queryKey: submissionKeys.lists() })
+			await revalidateAllSubmissions()
+			if (data.rejected > 0) {
+				toast.warning(`${data.fulfilled} of ${data.total} submissions rejected, ${data.rejected} failed`)
+			} else {
+				toast.success(`${data.total} submission${data.total > 1 ? "s" : ""} rejected`)
+			}
+		},
+		onError: (error: any) => {
+			console.error("Error bulk rejecting submissions:", error)
+			if (!error.message?.includes("autocancelled") && !error.name?.includes("AbortError")) {
+				toast.error("Failed to reject submissions", {
+					description: error.message || "An error occurred",
+				})
+			}
+		},
+	})
+}
+
 // Reject submission mutation
 export function useRejectSubmission() {
 	const queryClient = useQueryClient()


### PR DESCRIPTION
## Summary

Adds the ability for admins to reject multiple pending submissions at once, mirroring the existing bulk approve workflow.

### Changes
- **`useBulkRejectSubmissions` hook** — rejects submissions in parallel via `Promise.allSettled` (same pattern as bulk approve), with partial success handling and toast notifications
- **`BulkRejectDialog` component** — confirmation dialog (desktop) / drawer (mobile) with optional reason field
- **Reject button** in the bulk actions toolbar — shown when pending submissions are selected
- **`onBulkReject` / `isBulkRejecting` props** on `SubmissionsDataTable`

### How it works
1. Admin selects one or more pending submissions (checkboxes or "Select all pending")
2. Clicks the red "Reject (N)" button in the bulk toolbar
3. Confirms with an optional reason in the dialog
4. All rejections fire in parallel via `Promise.allSettled`
5. Toast shows success or partial-failure result

### Files changed
- `web/src/hooks/use-submissions.ts` — new `useBulkRejectSubmissions` hook
- `web/src/components/submissions-data-table.tsx` — reject button + props
- `web/src/app/dashboard/page.tsx` — dialog, state, handlers, wiring