### PR TITLE
fix(web): restore Docker build after MCP merge

### DIFF
--- a/web/src/instrumentation-node.ts
+++ b/web/src/instrumentation-node.ts
@@ -14,7 +14,7 @@ export function registerPostHogLogExporter(posthogKey: string, posthogHost: stri
 
 	const loggerProvider = new LoggerProvider({
 		resource: resourceFromAttributes({ "service.name": "dashboard-icons-web" }),
-		processors: [new BatchLogRecordProcessor(logExporter)],
+		processors: [new BatchLogRecordProcessor({ exporter: logExporter })],
 	})
 
 	logs.setGlobalLoggerProvider(loggerProvider)

--- a/web/src/mcp/__tests__/handler.test.ts
+++ b/web/src/mcp/__tests__/handler.test.ts
@@ -25,9 +25,11 @@ describe("createDashboardIconsMcpHandler", () => {
 		const handler = createDashboardIconsMcpHandler()
 		expect(instrumentDashboardIconsMcpAnalytics).toHaveBeenCalled()
 		expect(registerDashboardIconsTools).toHaveBeenCalled()
-		expect(createMcpHandler.mock.calls[0]).toHaveLength(2)
+		expect(createMcpHandler.mock.calls[0]).toHaveLength(3)
 		expect(createMcpHandler.mock.calls[0]?.[1]).toMatchObject({
 			serverInfo: expect.any(Object),
+		})
+		expect(createMcpHandler.mock.calls[0]?.[2]).toMatchObject({
 			verboseLogs: false,
 		})
 		expect(typeof handler).toBe("function")

--- a/web/src/mcp/handler.ts
+++ b/web/src/mcp/handler.ts
@@ -11,6 +11,8 @@ export const createDashboardIconsMcpHandler = () =>
 		},
 		{
 			serverInfo: getDashboardIconsServerInfo(),
+		},
+		{
 			verboseLogs: process.env.MCP_VERBOSE_LOGS === "true",
 		},
 	)


### PR DESCRIPTION
## Summary

Fixes the failed `build-and-push` job after merging #2885 ([run](https://github.com/homarr-labs/dashboard-icons/actions/runs/30716821465/job/91413686969)).

The Docker/Next.js build failed during TypeScript checking in `instrumentation-node.ts`:

```
Type error: Argument of type 'OTLPLogExporter' is not assignable to parameter of type 'BatchLogRecordProcessorOptions'.
```

## Changes

- Pass `{ exporter: logExporter }` to `BatchLogRecordProcessor` (OpenTelemetry SDK expects an options object, not the exporter directly)
- Restore `verboseLogs` to `createMcpHandler`'s third `config` argument (it is not part of `ServerOptions` in `mcp-handler` typings)

## Test plan

- [x] `pnpm build` passes locally
- [x] `pnpm test` passes (1019 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/homarr-labs/codesmith/dashboard-icons/pr/2886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788209766&installation_model_id=426862&pr_number=2886&repository=homarr-labs%2Fdashboard-icons&return_to=https%3A%2F%2Fgithub.com%2Fhomarr-labs%2Fdashboard-icons%2Fpull%2F2886&signature=6267d211c90c32697c36bef15bb053fc4f93800dca840640084155ea6195b541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling for dashboard integrations.
  * Enhanced reliability of log processing and message handling.
  * Updated validation to ensure integration settings are passed and interpreted consistently.

* **Tests**
  * Added coverage for configuration values and server information used during integration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->