### PR TITLE
fix(web): tolerate missing GitHub authors during static builds

### DIFF
--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -286,6 +286,14 @@ describe("api", () => {
 			expect(author.login).toBe("unknown")
 		})
 
+		it("returns unknown author when github user is not found", async () => {
+			vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" }))
+			const { getAuthorData, clearAuthorDataCacheForTests } = await loadApi()
+			clearAuthorDataCacheForTests()
+			const author = await getAuthorData(8)
+			expect(author.login).toBe("unknown")
+		})
+
 		it("throws ApiError for non-auth github failures", async () => {
 			vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: "Server Error" }))
 			const { getAuthorData, clearAuthorDataCacheForTests } = await loadApi()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -118,6 +118,10 @@ async function fetchGitHubAuthorData(authorId: number): Promise<AuthorData> {
 			return UNKNOWN_AUTHOR
 		}
 
+		if (response.status === 404) {
+			return UNKNOWN_AUTHOR
+		}
+
 		if (!response.ok) {
 			throw new ApiError(`Failed to fetch author data: ${response.statusText}`, response.status)
 		}


### PR DESCRIPTION
## Summary

Fixes the Docker `build-and-push` failure after merging #2886 ([run](https://github.com/homarr-labs/dashboard-icons/actions/runs/30718386164/job/91417871101)).

The TypeScript step passed, but static generation failed while prerendering `/icons/leanote`:

```
Error [ApiError]: Failed to fetch author data: Not Found
status: 404
```

Some icons reference GitHub user IDs that no longer exist. `fetchGitHubAuthorData` already falls back to `UNKNOWN_AUTHOR` for 401/403 and network errors, but 404 responses were thrown and aborted the entire build.

## Changes

- Return `UNKNOWN_AUTHOR` when the GitHub user API responds with 404
- Add a regression test for missing GitHub authors

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/api.test.ts`
- [x] `pnpm test` (1020 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub author information now displays as “Unknown” when the author cannot be found, including 404 responses.
  * Improved handling of unavailable or restricted author data.

* **Tests**
  * Added coverage to verify the unknown-author behavior for missing GitHub authors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->