### PR TITLE
fix(web): revert crossOrigin on Carbon Ads script to restore ads

### DIFF
--- a/web/src/components/carbon.tsx
+++ b/web/src/components/carbon.tsx
@@ -18,8 +18,6 @@ export function Carbon() {
 		const s = document.createElement("script")
 		s.id = "_carbonads_js"
 		s.async = true
-		// Request CORS so errors from the CDN arrive with a real stack instead of an opaque "Script error."
-		s.crossOrigin = "anonymous"
 		s.src = `https://cdn.carbonads.com/carbon.js?serve=${serve}&placement=${placement}`
 		el.appendChild(s)
 	}, [])


### PR DESCRIPTION
## What & why

Carbon Ads stopped rendering after the `crossOrigin = "anonymous"` attribute was added to the injected script (from PR #2889). Setting `crossOrigin` makes the browser fetch the script in CORS mode, and `cdn.carbonads.com` does not send `Access-Control-Allow-Origin` headers — so the script is blocked by the browser and the ad never shows.

## Change

Revert the single `crossOrigin = "anonymous"` line in `web/src/components/carbon.tsx`, restoring the plain script load that worked. The companion `before_send` "Script error." filter in `PostHogProvider.tsx` is kept — it still drops the opaque error noise, and remains useful if the CDN fails for other reasons.

## Verification

- `pnpm test` → 1028/1028 pass
- `biome check` clean on the changed file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading the Carbon script by adjusting its configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->