### PR TITLE
feat(web): add Simple Icons source

### DIFF
--- a/.github/workflows/sync-simple-icons.yml
+++ b/.github/workflows/sync-simple-icons.yml
@@ -1,0 +1,39 @@
+name: Sync Simple Icons
+
+on:
+  schedule:
+    - cron: "30 5 * * 1"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ env.ACT != 'true' }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Resolve and fetch the published Simple Icons catalogue
+        working-directory: web
+        run: |
+          mkdir -p data/sources/simpleicons
+          curl -fsSL https://registry.npmjs.org/simple-icons/latest -o data/sources/simpleicons/release.json
+          SIMPLE_ICONS_VERSION=$(bun -e 'const data = await Bun.file("data/sources/simpleicons/release.json").json(); process.stdout.write(data.version)')
+          curl -fsSL "https://api.github.com/repos/simple-icons/simple-icons/releases/tags/${SIMPLE_ICONS_VERSION}" -o data/sources/simpleicons/github-release.json
+          SIMPLE_ICONS_PUBLISHED_AT=$(bun -e 'const data = await Bun.file("data/sources/simpleicons/github-release.json").json(); process.stdout.write(data.published_at ?? "")')
+          curl -fsSL "https://cdn.jsdelivr.net/npm/simple-icons@${SIMPLE_ICONS_VERSION}/data/simple-icons.json" -o data/sources/simpleicons/simple-icons.json
+          echo "SIMPLE_ICONS_VERSION=${SIMPLE_ICONS_VERSION}" >> "$GITHUB_ENV"
+          echo "SIMPLE_ICONS_PUBLISHED_AT=${SIMPLE_ICONS_PUBLISHED_AT}" >> "$GITHUB_ENV"
+
+      - name: Import unique Simple Icons records
+        working-directory: web
+        env:
+          PB_URL: ${{ secrets.PB_URL }}
+          PB_ADMIN: ${{ secrets.PB_ADMIN }}
+          PB_ADMIN_PASS: ${{ secrets.PB_ADMIN_PASS }}
+        run: bun run scripts/import-simple-icons.ts

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Want to help with the repository itself?
 
 **Disclaimer**: All product names, trademarks, and registered trademarks are the property of their respective owners. Icons are used for identification purposes only and do not imply endorsement.
 
+The website also indexes externally hosted icons from [Simple Icons](https://simpleicons.org/), served through its
+[colorable CDN](https://cdn.simpleicons.org/). Simple Icons source links, guidelines, and license details are credited on
+each external icon page. Brand-color, black, and white variants are available as SVG and PNG,
+and catalogue previews automatically use black or white to match the website theme. Its CC0-1.0 collection license does
+not waive third-party trademark, patent, or brand-guideline restrictions.
+
 **License**: This project is available under the terms of the [LICENSE](LICENSE) file.
 
 ---

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -52,6 +52,8 @@ backend/pb_data
 scripts/*
 !scripts/import-selfhst.ts
 !scripts/import-lobehub.ts
+!scripts/import-simple-icons.ts
+data/sources/
 
 # Playwright
 node_modules/

--- a/web/README.md
+++ b/web/README.md
@@ -147,6 +147,40 @@ NEXT_PUBLIC_POCKETBASE_URL=http://127.0.0.1:8090 \
 bun run scripts/import-selfhst.ts
 ```
 
+## Third-party source: Simple Icons
+
+The external catalogue also includes unique brands from
+[Simple Icons](https://simpleicons.org/). A weekly Monday sync resolves the
+latest published npm release, imports its version-pinned metadata, and skips
+slugs already owned by Dashboard Icons or another external source.
+
+Every imported record preserves the official slug, brand color, source,
+guidelines, per-icon license metadata, and all searchable alias classes. The
+detail page lists SVG and PNG cards side by side for the brand-color, black
+(light-mode), and white (dark-mode) variants. SVGs remain hosted by the official
+colorable CDN:
+
+```txt
+https://cdn.simpleicons.org/<slug>/<brand-color>
+```
+
+PNG downloads are generated on demand as transparent 640 x 640 images from the
+corresponding official SVG. Browse and main detail previews follow the website
+theme directly, using black in light mode and white in dark mode. The source
+details page links back to the original brand source and guidelines and feeds
+the colored SVG into the existing customizer. The Simple Icons collection is
+released under CC0-1.0, but brand
+names and marks remain subject to their owners' licenses, trademarks, and usage
+guidelines. See the [Simple Icons disclaimer](https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md).
+
+To run the pinned importer locally after downloading the published metadata:
+
+```bash
+PB_ADMIN=admin@example.com PB_ADMIN_PASS=your-password \
+PB_URL=http://127.0.0.1:8090 SIMPLE_ICONS_VERSION=16.28.0 \
+bun run scripts/import-simple-icons.ts
+```
+
 ### Deployment
 
 The application is optimized for deployment on Vercel.

--- a/web/backend/pb_migrations/1778230800_add_simple_icons_source.js
+++ b/web/backend/pb_migrations/1778230800_add_simple_icons_source.js
@@ -1,0 +1,29 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+	const collection = app.findCollectionByNameOrId("external_icons")
+	const sourceField = collection.fields.find((field) => field.name === "source")
+	sourceField.values = ["selfhst", "lobehub", "simpleicons"]
+
+	collection.fields.add(new Field({ name: "brand_color", type: "text", pattern: "^[0-9A-Fa-f]{6}$" }))
+	collection.fields.add(new Field({ name: "guidelines_url", type: "url" }))
+	collection.fields.add(new Field({ name: "license_url", type: "url" }))
+	collection.fields.add(new Field({ name: "stable_svg_url", type: "url" }))
+	collection.fields.add(new Field({ name: "upstream_version", type: "text" }))
+	collection.fields.add(new Field({ name: "upstream_data", type: "json" }))
+
+	return app.save(collection)
+}, (app) => {
+	const collection = app.findCollectionByNameOrId("external_icons")
+	const simpleIconRecords = app.findRecordsByFilter(collection, "source = 'simpleicons'", "", 0, 0)
+	for (const record of simpleIconRecords) app.delete(record)
+
+	const sourceField = collection.fields.find((field) => field.name === "source")
+	sourceField.values = ["selfhst", "lobehub"]
+
+	for (const name of ["brand_color", "guidelines_url", "license_url", "stable_svg_url", "upstream_version", "upstream_data"]) {
+		const field = collection.fields.find((candidate) => candidate.name === name)
+		if (field) collection.fields.removeById(field.id)
+	}
+
+	return app.save(collection)
+})

--- a/web/docs/ADDING_EXTERNAL_SOURCES.md
+++ b/web/docs/ADDING_EXTERNAL_SOURCES.md
@@ -403,7 +403,7 @@ The dropdown renders one `DropdownMenuRadioItem` per entry in `EXTERNAL_SOURCE_I
 
 ### Icon card badges — `src/components/icon-card.tsx`
 
-When an icon has `source !== "native"`, hovering the card reveals a banner above it showing the source icon and "from {label}". The card also uses `getExternalIconThemedPreviewUrl()` to show light/dark themed previews matching the user's current theme (via `next-themes`). Native icons similarly use `iconData.colors.dark`/`.light` for theme-aware previews.
+When an icon has `source !== "native"`, hovering the card reveals a banner above it showing the source icon and "from {label}". External previews use `getExternalIconPreviewUrl()`. Sources that need app-theme-specific behavior can add a source-specific card treatment; Simple Icons uses one black SVG and CSS inversion in dark mode so only one preview asset is loaded. Native icons similarly use `iconData.colors.dark`/`.light` for theme-aware previews.
 
 ### Detail page — `src/components/icon-details.tsx`
 
@@ -444,7 +444,7 @@ Iterates over all external icons and generates `<url>` entries with `<image>` ta
 
 ### URL resolution — `src/lib/external-icon-urls.ts`
 
-`resolveExternalIconUrl()` first checks `url_templates[key]` for an exact match (e.g. `png_dark`), then falls back to `{cdnBase}/{format}/{slug}.{format}`. The `cdnBase` is read from `EXTERNAL_SOURCES[icon.source]`. `getExternalIconThemedPreviewUrl()` selects the best preview URL based on the current theme. The detail page's `renderVariant()` only renders a format+theme card when the exact template key exists in `url_templates` — missing templates are skipped, not guessed.
+`resolveExternalIconUrl()` first checks `url_templates[key]` for an exact match (for example `png_dark`). Sources with deterministic URL layouts can define a source-specific fallback builder; other sources use `{cdnBase}/{format}/{slug}.{format}`. `canResolveExternalIconUrl()` only reports fallback keys explicitly supported by that source, preventing invented variants such as `-auto.svg`. The detail page also checks the icon's declared formats and variants before rendering a card.
 
 ### Types — `src/types/icons.ts`
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,6 +4,9 @@ import type { NextConfig } from "next";
 import { withPostHogConfig } from "@posthog/nextjs-config";
 
 const projectRoot = path.dirname(fileURLToPath(import.meta.url))
+const allowedDevOrigins = process.env.NEXT_ALLOWED_DEV_ORIGINS?.split(",")
+	.map((origin) => origin.trim())
+	.filter(Boolean)
 
 const securityHeaders = [
 	{ key: "X-Content-Type-Options", value: "nosniff" },
@@ -14,6 +17,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+	...(allowedDevOrigins?.length ? { allowedDevOrigins } : {}),
 	turbopack: {
 		root: projectRoot,
 	},

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
 		baseURL: "http://localhost:3005",
 		trace: "on-first-retry",
 		screenshot: "only-on-failure",
+		launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+			? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+			: undefined,
 	},
 
 	projects: [

--- a/web/scripts/import-simple-icons.ts
+++ b/web/scripts/import-simple-icons.ts
@@ -1,0 +1,246 @@
+import fs from "node:fs"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import PocketBase from "pocketbase"
+
+const SOURCE = "simpleicons"
+const DISCLAIMER_URL = "https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md"
+const DEFAULT_MANIFEST = "data/sources/simpleicons/simple-icons.json"
+const IMPORT_SCHEMA_VERSION = 2
+
+type DuplicateAlias = {
+	title?: string
+	hex?: string
+	loc?: Record<string, string>
+}
+
+type SimpleIconAliases = {
+	aka?: string[]
+	dup?: Array<string | DuplicateAlias>
+	loc?: Record<string, string>
+	old?: string[]
+}
+
+export type SimpleIconData = {
+	title: string
+	slug: string
+	hex: string
+	source: string
+	guidelines?: string
+	license?: { type?: string; url?: string }
+	aliases?: SimpleIconAliases
+}
+
+type BuildOptions = {
+	version?: string
+	publishedAt?: string | null
+}
+
+function normalizeAlias(value: string): string {
+	return value.trim()
+}
+
+function collectAliases(icon: SimpleIconData): string[] {
+	const aliases = icon.aliases
+	if (!aliases) return []
+
+	const values = [
+		...(aliases.aka ?? []),
+		...Object.values(aliases.loc ?? {}),
+		...(aliases.old ?? []),
+		...(aliases.dup ?? []).flatMap((duplicate) => {
+			if (typeof duplicate === "string") return [duplicate]
+			return [duplicate.title, ...Object.values(duplicate.loc ?? {})].filter((value): value is string => Boolean(value))
+		}),
+	]
+	const excluded = new Set([icon.title.toLocaleLowerCase(), icon.slug.toLocaleLowerCase()])
+	const seen = new Set<string>()
+
+	return values
+		.map(normalizeAlias)
+		.filter(Boolean)
+		.filter((value) => {
+			const key = value.toLocaleLowerCase()
+			if (excluded.has(key) || seen.has(key)) return false
+			seen.add(key)
+			return true
+		})
+}
+
+function validateIcon(icon: SimpleIconData): void {
+	if (!icon.title?.trim() || !icon.slug?.trim() || !icon.source?.trim()) {
+		throw new Error(`Invalid Simple Icons entry: ${JSON.stringify(icon)}`)
+	}
+	if (!/^[0-9A-F]{6}$/i.test(icon.hex)) {
+		throw new Error(`Invalid brand color for ${icon.slug}: ${icon.hex}`)
+	}
+}
+
+export function buildSimpleIconRecords(
+	upstreamIcons: SimpleIconData[],
+	excludedSlugs: Set<string>,
+	options: BuildOptions = {},
+) {
+	const normalizedExcluded = new Set(Array.from(excludedSlugs, (slug) => slug.toLocaleLowerCase()))
+	const seen = new Set<string>()
+	const version = options.version ?? "latest"
+
+	return upstreamIcons.flatMap((icon) => {
+		validateIcon(icon)
+		const slug = icon.slug.toLocaleLowerCase()
+		if (normalizedExcluded.has(slug) || seen.has(slug)) return []
+		seen.add(slug)
+		const license = icon.license?.type || ""
+		const attribution = license
+			? `${icon.title.trim()} icon by Simple Icons (${license}). Brand marks remain subject to their owners' terms.`
+			: `${icon.title.trim()} icon via Simple Icons. Brand marks remain subject to their owners' terms.`
+
+		return [{
+			source: SOURCE,
+			slug,
+			name: icon.title.trim(),
+			aliases: collectAliases(icon),
+			categories: [],
+			formats: ["svg", "png"],
+			variants: { light: true, dark: true },
+			url_templates: {
+				svg: "https://cdn.simpleicons.org/{slug}/{hex}",
+				svg_auto: "https://cdn.simpleicons.org/{slug}/000000/FFFFFF",
+				svg_light: "https://cdn.simpleicons.org/{slug}/000000",
+				svg_dark: "https://cdn.simpleicons.org/{slug}/FFFFFF",
+				png: "/api/icons/external/simpleicons/{slug}/brand.png",
+				png_light: "/api/icons/external/simpleicons/{slug}/light.png",
+				png_dark: "/api/icons/external/simpleicons/{slug}/dark.png",
+			},
+			brand_color: icon.hex.toUpperCase(),
+			license,
+			license_url: icon.license?.url || "",
+			attribution,
+			source_url: icon.source,
+			guidelines_url: icon.guidelines || "",
+			stable_svg_url: `https://cdn.jsdelivr.net/npm/simple-icons@${version}/icons/${slug}.svg`,
+			upstream_version: version,
+			upstream_data: {
+				import_schema_version: IMPORT_SCHEMA_VERSION,
+				aliases: icon.aliases ?? {},
+				disclaimer_url: DISCLAIMER_URL,
+			},
+			updated_at_source: options.publishedAt ?? null,
+		}]
+	})
+}
+
+function parseArgs() {
+	return process.argv.slice(2).reduce(
+		(flags, arg) => {
+			if (arg === "--dry-run") flags.dryRun = true
+			if (arg === "--purge") flags.purge = true
+			if (arg.startsWith("--manifest=")) flags.manifest = arg.slice("--manifest=".length)
+			if (arg.startsWith("--version=")) flags.version = arg.slice("--version=".length)
+			if (arg.startsWith("--published-at=")) flags.publishedAt = arg.slice("--published-at=".length)
+			return flags
+		},
+		{ dryRun: false, purge: false, manifest: DEFAULT_MANIFEST, version: process.env.SIMPLE_ICONS_VERSION ?? "latest", publishedAt: process.env.SIMPLE_ICONS_PUBLISHED_AT ?? null } as {
+			dryRun: boolean
+			purge: boolean
+			manifest: string
+			version: string
+			publishedAt: string | null
+		},
+	)
+}
+
+function readManifest(manifestPath: string): SimpleIconData[] {
+	const absolutePath = path.resolve(process.cwd(), manifestPath)
+	const parsed = JSON.parse(fs.readFileSync(absolutePath, "utf8")) as unknown
+	if (!Array.isArray(parsed) || parsed.length === 0) throw new Error("Simple Icons manifest must be a non-empty array")
+	return parsed as SimpleIconData[]
+}
+
+function readNativeSlugs(): Set<string> {
+	const metadataPath = path.resolve(process.cwd(), "../metadata.json")
+	const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as Record<string, unknown>
+	return new Set(Object.keys(metadata).map((slug) => slug.toLocaleLowerCase()))
+}
+
+async function main() {
+	const flags = parseArgs()
+	const adminEmail = process.env.PB_ADMIN
+	const adminPassword = process.env.PB_ADMIN_PASS
+	if (!adminEmail || !adminPassword) throw new Error("PB_ADMIN and PB_ADMIN_PASS are required")
+
+	const pbUrl = process.env.NEXT_PUBLIC_POCKETBASE_URL || process.env.PB_URL || "http://127.0.0.1:8090"
+	const pb = new PocketBase(pbUrl)
+	await pb.collection("_superusers").authWithPassword(adminEmail, adminPassword)
+
+	const current = await pb.collection("external_icons").getFullList({
+		fields: "id,source,slug,upstream_version,upstream_data,updated_at_source",
+		requestKey: null,
+	})
+	const currentSimpleIcons = current.filter((record) => record.source === SOURCE)
+
+	if (flags.purge) {
+		for (const record of currentSimpleIcons) {
+			if (!flags.dryRun) await pb.collection("external_icons").delete(record.id)
+		}
+		console.log(`${flags.dryRun ? "Would remove" : "Removed"} ${currentSimpleIcons.length} Simple Icons records`)
+		return
+	}
+
+	const excludedSlugs = readNativeSlugs()
+	for (const record of current) {
+		if (record.source !== SOURCE) excludedSlugs.add(String(record.slug).toLocaleLowerCase())
+	}
+
+	const upstream = readManifest(flags.manifest)
+	const records = buildSimpleIconRecords(upstream, excludedSlugs, { version: flags.version, publishedAt: flags.publishedAt })
+	const existingBySlug = new Map(currentSimpleIcons.map((record) => [String(record.slug), String(record.id)]))
+	const targetSlugs = new Set(records.map((record) => record.slug))
+	const expectedPublishedAt = flags.publishedAt ? new Date(flags.publishedAt).getTime() : null
+	const isAlreadyCurrent =
+		currentSimpleIcons.length === records.length &&
+		currentSimpleIcons.every(
+			(record) =>
+				record.upstream_version === flags.version &&
+				record.upstream_data?.import_schema_version === IMPORT_SCHEMA_VERSION &&
+				targetSlugs.has(String(record.slug)) &&
+				(expectedPublishedAt === null || new Date(String(record.updated_at_source)).getTime() === expectedPublishedAt),
+		)
+	if (isAlreadyCurrent) {
+		console.log(`Simple Icons ${flags.version} is already current: ${records.length} records, ${upstream.length - records.length} duplicates skipped`)
+		return
+	}
+	const importedSlugs = new Set<string>()
+	let created = 0
+	let updated = 0
+	let removed = 0
+
+	for (const record of records) {
+		importedSlugs.add(record.slug)
+		const existingId = existingBySlug.get(record.slug)
+		if (!flags.dryRun) {
+			if (existingId) await pb.collection("external_icons").update(existingId, record)
+			else await pb.collection("external_icons").create(record)
+		}
+		existingId ? updated++ : created++
+	}
+
+	for (const [slug, id] of existingBySlug) {
+		if (importedSlugs.has(slug)) continue
+		if (!flags.dryRun) await pb.collection("external_icons").delete(id)
+		removed++
+	}
+
+	const skippedDuplicates = upstream.length - records.length
+	console.log(
+		`Simple Icons ${flags.version} sync: ${created} created, ${updated} updated, ${removed} removed, ${skippedDuplicates} duplicates skipped${flags.dryRun ? " (dry run)" : ""}`,
+	)
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : ""
+if (import.meta.url === invokedPath) {
+	main().catch((error) => {
+		console.error(error)
+		process.exit(1)
+	})
+}

--- a/web/src/app/api/icons/external/simpleicons/[slug]/[variant]/route.tsx
+++ b/web/src/app/api/icons/external/simpleicons/[slug]/[variant]/route.tsx
@@ -1,0 +1,48 @@
+import { ImageResponse } from "next/og"
+import { resolveExternalIconUrl } from "@/lib/external-icon-urls"
+import { getExternalIconBySourceAndSlug } from "@/lib/external-icons"
+
+const PNG_SIZE = 640
+const VARIANT_KEYS = {
+	brand: "svg",
+	light: "svg_light",
+	dark: "svg_dark",
+} as const
+
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string; variant: string }> }) {
+	const { slug, variant: rawVariant } = await params
+	const variant = rawVariant.replace(/\.png$/, "") as keyof typeof VARIANT_KEYS
+	const svgKey = VARIANT_KEYS[variant]
+
+	if (!svgKey) return new Response("Unknown Simple Icons color variant", { status: 400 })
+
+	const icon = await getExternalIconBySourceAndSlug("simpleicons", slug)
+	if (!icon) return new Response("Simple Icon not found", { status: 404 })
+
+	// Keep this server-side fetch pinned to the official Simple Icons CDN even if
+	// a stored URL template is accidentally or maliciously changed.
+	const svgUrl = resolveExternalIconUrl({ ...icon.external, url_templates: {} }, svgKey)
+
+	return new ImageResponse(
+		<div
+			style={{
+				display: "flex",
+				width: "100%",
+				height: "100%",
+				alignItems: "center",
+				justifyContent: "center",
+				backgroundColor: "transparent",
+			}}
+		>
+			{/* biome-ignore lint/performance/noImgElement: ImageResponse requires a native image element */}
+			<img src={svgUrl} alt="" width={PNG_SIZE} height={PNG_SIZE} style={{ objectFit: "contain" }} />
+		</div>,
+		{
+			width: PNG_SIZE,
+			height: PNG_SIZE,
+			headers: {
+				"Cache-Control": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400",
+			},
+		},
+	)
+}

--- a/web/src/app/api/icons/search/route.ts
+++ b/web/src/app/api/icons/search/route.ts
@@ -2,14 +2,38 @@ import { unstable_cache } from "next/cache"
 import { NextResponse } from "next/server"
 import { getIconsArray } from "@/lib/api"
 import { getExternalIcons } from "@/lib/external-icons"
-import type { IconWithName } from "@/types/icons"
+import type { IconSearchEntry, IconWithName } from "@/types/icons"
 
 const REVALIDATE_SECONDS = 900
 
+function toCommandMenuEntry(icon: IconWithName): IconSearchEntry {
+	return {
+		name: icon.name,
+		source: icon.source,
+		slug: icon.slug,
+		data: {
+			base: icon.data.base,
+			aliases: icon.data.aliases,
+			categories: icon.data.categories,
+		},
+		...(icon.external
+			? {
+					external: {
+						source: icon.external.source,
+						slug: icon.external.slug,
+						formats: icon.external.formats,
+						url_templates: icon.external.url_templates,
+						brand_color: icon.external.brand_color,
+					},
+				}
+			: {}),
+	}
+}
+
 const getCachedIconList = unstable_cache(
-	async (): Promise<IconWithName[]> => {
+	async (): Promise<IconSearchEntry[]> => {
 		const [native, external] = await Promise.all([getIconsArray(), getExternalIcons()])
-		return [...native, ...external]
+		return [...native, ...external].map(toCommandMenuEntry)
 	},
 	["icons-search-list"],
 	{ revalidate: REVALIDATE_SECONDS, tags: ["icons-search"] },

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -221,6 +221,8 @@
 	--shadow-2xl: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0);
 
 	--magic-gradient-color: oklch(0.6723 0.1606 244.9955 / 15%);
+	--magic-border-from: #1e9df1;
+	--magic-border-to: #8ed0f9;
 
 	--ring: oklch(0.6818 0.1584 243.354);
 
@@ -302,6 +304,8 @@
 	--shadow-2xl: 0px 2px 0px 0px hsl(202.8169 89.1213% 53.1373% / 0);
 
 	--magic-gradient-color: oklch(0.67 0.2 23.8 / 15%);
+	--magic-border-from: #ffb3c1;
+	--magic-border-to: #ff75a0;
 
 	--radius: 0.3rem;
 

--- a/web/src/app/icons/external/[slug]/page.tsx
+++ b/web/src/app/icons/external/[slug]/page.tsx
@@ -6,9 +6,9 @@ import { getExternalIconPreviewUrl, resolveExternalIconUrl } from "@/lib/externa
 import { getExternalIconBySlug, getExternalIcons } from "@/lib/external-icons"
 import type { AuthorData } from "@/types/icons"
 
-export const dynamicParams = false
+export const dynamicParams = true
 export const dynamic = "force-static"
-export const revalidate = false
+export const revalidate = 900
 
 export async function generateStaticParams() {
 	const icons = await getExternalIcons()
@@ -40,13 +40,20 @@ export async function generateMetadata({ params }: Props, _parent: ResolvingMeta
 		notFound()
 	}
 	const formattedName = icon.external.name
+	const license = icon.external.license
+	const licenseDescription = license ? ` Licensed under ${license}.` : ""
 	const pageUrl = `${WEB_URL}/icons/external/${slug}`
 	const previewUrl = getExternalIconPreviewUrl(icon.external)
-	const imageType = previewUrl.endsWith(".svg") ? "image/svg+xml" : previewUrl.endsWith(".webp") ? "image/webp" : "image/png"
+	const previewFormat = icon.external.formats.includes("svg")
+		? "svg"
+		: icon.external.formats.includes("png")
+			? "png"
+			: icon.external.formats[0]
+	const imageType = previewFormat === "svg" ? "image/svg+xml" : previewFormat === "webp" ? "image/webp" : "image/png"
 
 	return {
 		title: `${formattedName} Icon & Logo (${sourceConfig.label})`,
-		description: `Download the ${formattedName} icon and logo from ${sourceConfig.label} via Dashboard Icons. Licensed under ${sourceConfig.license}.`,
+		description: `Download the ${formattedName} icon and logo from ${sourceConfig.label} via Dashboard Icons.${licenseDescription}`,
 		assets: icon.external.formats.map((format) => resolveExternalIconUrl(icon.external, format)),
 		keywords: [
 			`${formattedName} icon`,
@@ -75,7 +82,7 @@ export async function generateMetadata({ params }: Props, _parent: ResolvingMeta
 		},
 		openGraph: {
 			title: `${formattedName} Icon & Logo (${sourceConfig.label})`,
-			description: `Download the ${formattedName} icon and logo from ${sourceConfig.label}. Licensed under ${sourceConfig.license}.`,
+			description: `Download the ${formattedName} icon and logo from ${sourceConfig.label}.${licenseDescription}`,
 			type: "website",
 			url: pageUrl,
 			siteName: "Dashboard Icons",
@@ -141,9 +148,9 @@ export default async function ExternalIconPage({ params }: { params: Promise<{ s
 						"@context": "https://schema.org",
 						"@type": "ImageObject",
 						contentUrl: previewUrl,
-						license:
-							sourceConfig.license === "MIT" ? "https://opensource.org/licenses/MIT" : "https://creativecommons.org/licenses/by/4.0/",
-						acquireLicensePage: `${WEB_URL}/license`,
+						license: icon.external.license_url || undefined,
+						acquireLicensePage: icon.external.license_url || icon.external.source_url,
+						creditText: icon.external.attribution,
 						creator: {
 							"@type": "Organization",
 							name: sourceConfig.authorName,

--- a/web/src/components/command-menu.tsx
+++ b/web/src/components/command-menu.tsx
@@ -12,20 +12,20 @@ import { EXTERNAL_SOURCES, type ExternalSourceId } from "@/constants"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { getIconImageUrl } from "@/lib/icon-url"
 import { filterAndSortIcons, formatIconName } from "@/lib/utils"
-import type { IconWithName } from "@/types/icons"
+import type { IconSearchEntry } from "@/types/icons"
 
 function normalizeCmdkValue(s: string): string {
 	return s.trim().toLowerCase().replace(/[\s-]/g, " ")
 }
 
-function getItemValue(icon: IconWithName): string {
+function getItemValue(icon: IconSearchEntry): string {
 	const isExternal = icon.source && icon.source !== "native"
 	const sourceConfig = isExternal ? EXTERNAL_SOURCES[icon.source as ExternalSourceId] : undefined
 	return `${icon.name}${isExternal ? ` ${sourceConfig?.label}` : ""}`
 }
 
 interface CommandMenuProps {
-	icons: IconWithName[]
+	icons: IconSearchEntry[]
 	triggerButtonId?: string
 	open?: boolean
 	onOpenChange?: (open: boolean) => void
@@ -36,7 +36,7 @@ export function CommandMenu({ icons, open: externalOpen, onOpenChange: externalO
 	const [internalOpen, setInternalOpen] = useState(false)
 	const [query, setQuery] = useState("")
 	const [cmdkValue, setCmdkValue] = useState("")
-	const [selectedIcon, setSelectedIcon] = useState<IconWithName | null>(null)
+	const [selectedIcon, setSelectedIcon] = useState<IconSearchEntry | null>(null)
 	const isDesktop = useMediaQuery("(min-width: 768px)")
 
 	const isOpen = externalOpen !== undefined ? externalOpen : internalOpen
@@ -64,7 +64,7 @@ export function CommandMenu({ icons, open: externalOpen, onOpenChange: externalO
 	const totalIcons = icons.length
 
 	const iconsByValue = useMemo(() => {
-		const map = new Map<string, IconWithName>()
+		const map = new Map<string, IconSearchEntry>()
 		for (const icon of filteredIcons) {
 			map.set(normalizeCmdkValue(getItemValue(icon)), icon)
 		}
@@ -103,7 +103,7 @@ export function CommandMenu({ icons, open: externalOpen, onOpenChange: externalO
 		return () => document.removeEventListener("keydown", handleKeyDown)
 	}, [isOpen, setIsOpen])
 
-	const handleSelect = (icon: IconWithName) => {
+	const handleSelect = (icon: IconSearchEntry) => {
 		setIsOpen(false)
 		if (icon.source && icon.source !== "native") {
 			router.push(`/icons/external/${icon.slug || icon.name}`)

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -10,7 +10,7 @@ import { ThemeSwitcher } from "@/components/theme-switcher"
 import { REPO_NAME, REPO_PATH } from "@/constants"
 import { pb } from "@/lib/pb"
 import { resetPostHogIdentity } from "@/lib/posthog-utils"
-import type { IconWithName } from "@/types/icons"
+import type { IconSearchEntry } from "@/types/icons"
 
 const CommandMenu = dynamic(() => import("./command-menu").then((mod) => mod.CommandMenu), { ssr: false })
 
@@ -34,7 +34,7 @@ function formatStars(stars: number): string {
 }
 
 export function Header() {
-	const [iconsData, setIconsData] = useState<IconWithName[]>([])
+	const [iconsData, setIconsData] = useState<IconSearchEntry[]>([])
 	const [isLoaded, setIsLoaded] = useState(false)
 	const [commandMenuOpen, setCommandMenuOpen] = useState(false)
 	const [loginModalOpen, setLoginModalOpen] = useState(false)

--- a/web/src/components/icon-card.tsx
+++ b/web/src/components/icon-card.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { MagicCard } from "@/components/magicui/magic-card"
 import { UnoptimizedImage } from "@/components/unoptimized-image"
 import { EXTERNAL_SOURCES, type ExternalSourceId } from "@/constants"
+import { resolveExternalIconUrl } from "@/lib/external-icon-urls"
 import { getIconImageUrl } from "@/lib/icon-url"
 import { formatIconName } from "@/lib/utils"
 import type { IconWithName } from "@/types/icons"
@@ -34,24 +35,35 @@ export function IconCard({ icon, matchedAlias }: { icon: IconWithName; matchedAl
 	const kind = getIconKind(icon)
 	const sourceConfig = kind.type === "external" ? EXTERNAL_SOURCES[kind.sourceId] : undefined
 	const imageUrl = getIconImageUrl(icon)
+	const themedExternalIcon = kind.type === "external" && kind.sourceId === "simpleicons" ? icon.external : undefined
 
 	return (
-		<MagicCard className="group/card rounded-md shadow-md">
+		<MagicCard className="rounded-md shadow-md">
 			{sourceConfig && (
-				<div className="absolute left-0 -top-7 z-10 flex items-center gap-1.5 pr-2 opacity-0 group-hover/card:opacity-100 transition-opacity duration-200 bg-muted/90 backdrop-blur-sm rounded-md shadow-sm whitespace-nowrap">
-					<UnoptimizedImage src={sourceConfig.icon} alt={sourceConfig.label} width={28} height={28} className="shrink-0" />
-					<span className="text-sm sm:text-md text-muted-foreground">from {sourceConfig.label}</span>
+				<div className="pointer-events-none absolute left-0 -top-8 z-10 inline-flex h-7 max-w-[calc(100vw-1rem)] items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-md border border-border/70 bg-background/95 px-2 opacity-0 shadow-sm transition-opacity duration-200 group-hover:opacity-100">
+					<UnoptimizedImage src={sourceConfig.icon} alt="" width={18} height={18} className="shrink-0" />
+					<span className="truncate text-xs leading-none text-foreground/80">from {sourceConfig.label}</span>
 				</div>
 			)}
 			<Link prefetch={false} href={getLinkHref(kind, name)} className="group flex flex-col items-center p-3 sm:p-4 cursor-pointer">
 				<div className="mb-2 flex h-16 w-16 items-center justify-center rounded-lg ring-1 ring-white/5 dark:ring-white/10 bg-primary/15 dark:bg-secondary/10">
-					<UnoptimizedImage
-						src={imageUrl}
-						alt={`${name} icon and logo`}
-						width={56}
-						height={56}
-						className="max-h-full max-w-full object-contain p-2 transition-transform duration-300 group-hover:scale-110"
-					/>
+					{themedExternalIcon ? (
+						<UnoptimizedImage
+							src={resolveExternalIconUrl(themedExternalIcon, "svg_light")}
+							alt={`${name} icon and logo`}
+							width={56}
+							height={56}
+							className="max-h-full max-w-full object-contain p-2 transition-transform duration-300 group-hover:scale-110 dark:invert"
+						/>
+					) : (
+						<UnoptimizedImage
+							src={imageUrl}
+							alt={`${name} icon and logo`}
+							width={56}
+							height={56}
+							className="max-h-full max-w-full object-contain p-2 transition-transform duration-300 group-hover:scale-110"
+						/>
+					)}
 				</div>
 				<span className="text-xs sm:text-sm text-center truncate w-full capitalize group-hover:text-primary dark:group-hover:text-primary transition-colors duration-200 font-medium">
 					{formatIconName(name)}

--- a/web/src/components/icon-details.tsx
+++ b/web/src/components/icon-details.tsx
@@ -2,7 +2,7 @@
 
 import confetti from "canvas-confetti"
 import { AnimatePresence, motion } from "framer-motion"
-import { ArrowRight, Check, ExternalLink, FileType, Github, Moon, Palette, PaletteIcon, Sun, Type } from "lucide-react"
+import { ArrowRight, ExternalLink, FileType, Github, Moon, Palette, PaletteIcon, Sun, Type } from "lucide-react"
 import Link from "next/link"
 import posthog from "posthog-js"
 import type React from "react"
@@ -29,6 +29,7 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbP
 import { Separator } from "./ui/separator"
 
 type RenderVariantFn = (format: string, iconName: string, theme?: "light" | "dark") => React.ReactNode
+const SIMPLE_ICONS_DISCLAIMER_URL = "https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md"
 
 const COPY_SUPPORTED_FORMATS = new Set(["svg", "png", "webp"])
 
@@ -36,12 +37,9 @@ type IconVariantsSectionProps = {
 	title: string
 	description: string
 	iconElement: React.ReactNode
-	aavailableFormats: string[]
+	availableFormats: string[]
 	icon: string
 	iconData: Icon
-	handleCopy: (url: string, variantKey: string, event?: React.MouseEvent) => void
-	handleDownload: (event: React.MouseEvent, url: string, filename: string) => Promise<void>
-	copiedVariants: Record<string, boolean>
 	theme?: "light" | "dark"
 	renderVariant: RenderVariantFn
 }
@@ -50,7 +48,7 @@ function IconVariantsSection({
 	title,
 	description,
 	iconElement,
-	aavailableFormats,
+	availableFormats,
 	icon,
 	iconData,
 	theme,
@@ -65,7 +63,7 @@ function IconVariantsSection({
 			</h3>
 			<p className="text-sm text-muted-foreground mb-4">{description}</p>
 			<MagicCardPointerProvider className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-				{aavailableFormats.map((format) => renderVariant(format, iconName, theme))}
+				{availableFormats.map((format) => renderVariant(format, iconName, theme))}
 			</MagicCardPointerProvider>
 		</div>
 	)
@@ -74,14 +72,11 @@ function IconVariantsSection({
 type WordmarkSectionProps = {
 	iconData: Icon
 	icon: string
-	aavailableFormats: string[]
-	handleCopy: (url: string, variantKey: string, event?: React.MouseEvent) => void
-	handleDownload: (event: React.MouseEvent, url: string, filename: string) => Promise<void>
-	copiedVariants: Record<string, boolean>
+	availableFormats: string[]
 	renderVariant: RenderVariantFn
 }
 
-function WordmarkSection({ iconData, aavailableFormats, renderVariant }: WordmarkSectionProps) {
+function WordmarkSection({ iconData, availableFormats, renderVariant }: WordmarkSectionProps) {
 	if (!iconData.wordmark) return null
 
 	return (
@@ -99,7 +94,7 @@ function WordmarkSection({ iconData, aavailableFormats, renderVariant }: Wordmar
 							Light Theme Wordmark
 						</h4>
 						<MagicCardPointerProvider className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-							{aavailableFormats.map((format) => {
+							{availableFormats.map((format) => {
 								if (!iconData.wordmark?.light) return null
 								return renderVariant(format, iconData.wordmark.light, "light")
 							})}
@@ -113,7 +108,7 @@ function WordmarkSection({ iconData, aavailableFormats, renderVariant }: Wordmar
 							Dark Theme Wordmark
 						</h4>
 						<MagicCardPointerProvider className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-							{aavailableFormats.map((format) => {
+							{availableFormats.map((format) => {
 								if (!iconData.wordmark?.dark) return null
 								return renderVariant(format, iconData.wordmark.dark, "dark")
 							})}
@@ -172,6 +167,7 @@ export function IconDetails({
 	})
 
 	const isExternalIcon = !!externalIcon
+	const isSimpleIcons = externalIcon?.source === "simpleicons"
 	const externalSourceConfig = externalIcon ? EXTERNAL_SOURCES[externalIcon.source as ExternalSourceId] : undefined
 	const externalPreviewUrl = externalIcon ? getExternalIconPreviewUrl(externalIcon) : null
 
@@ -252,7 +248,6 @@ export function IconDetails({
 	}
 
 	const availableFormats = getAvailableFormats()
-	const [copiedVariants, _setCopiedVariants] = useState<Record<string, boolean>>({})
 	const [copiedUrlKey, setCopiedUrlKey] = useState<string | null>(null)
 	const [copiedImageKey, setCopiedImageKey] = useState<string | null>(null)
 	const [isCustomizerOpen, setIsCustomizerOpen] = useState(false)
@@ -297,7 +292,8 @@ export function IconDetails({
 		}
 
 		try {
-			await navigator.clipboard.writeText(url)
+			const copyableUrl = url.startsWith("/") ? new URL(url, window.location.origin).href : url
+			await navigator.clipboard.writeText(copyableUrl)
 			setCopiedUrlKey(variantKey)
 			posthog.capture("icon_url_copied", {
 				icon_name: icon,
@@ -506,7 +502,6 @@ export function IconDetails({
 		}
 
 		const variantKey = `${format}-${theme || "default"}`
-		const isCopied = copiedVariants[variantKey] || false
 
 		return (
 			<TooltipProvider key={variantKey} delayDuration={500}>
@@ -519,38 +514,23 @@ export function IconDetails({
 									whileHover={{ scale: 1.05 }}
 									whileTap={{ scale: 0.95 }}
 									onClick={(e) => handleCopyUrl(imageUrl, variantKey, e)}
+									onKeyDown={(event) => {
+										if (event.key === "Enter" || event.key === " ") {
+											event.preventDefault()
+											handleCopyUrl(imageUrl, variantKey)
+										}
+									}}
+									role="button"
+									tabIndex={0}
 									aria-label={`Copy ${format.toUpperCase()} URL for ${iconName}${theme ? ` (${theme} theme)` : ""}`}
 								>
 									<div className="absolute inset-0 border-2 border-transparent group-hover:border-primary/20 rounded-xl z-10 transition-colors" />
-
-									<motion.div
-										className="absolute inset-0 bg-primary/10 flex items-center justify-center z-20 rounded-xl"
-										initial={{ opacity: 0 }}
-										animate={{ opacity: isCopied ? 1 : 0 }}
-										transition={{ duration: 0.2 }}
-									>
-										<motion.div
-											initial={{ scale: 0.5, opacity: 0 }}
-											animate={{
-												scale: isCopied ? 1 : 0.5,
-												opacity: isCopied ? 1 : 0,
-											}}
-											transition={{
-												type: "spring",
-												stiffness: 300,
-												damping: 20,
-											}}
-										>
-											<Check className="w-8 h-8 text-primary" />
-										</motion.div>
-									</motion.div>
 
 									<UnoptimizedImage
 										src={imageUrl}
 										alt={`${iconName} in ${format} format${theme ? ` (${theme} theme)` : ""}`}
 										width={88}
 										height={88}
-										priority
 										className="max-h-full max-w-full object-contain p-4"
 									/>
 								</motion.div>
@@ -580,7 +560,7 @@ export function IconDetails({
 		)
 	}
 
-	const formatedIconName = formatIconName(icon)
+	const formatedIconName = externalIcon?.name ?? formatIconName(icon)
 
 	type VariantOption = {
 		value: string
@@ -593,7 +573,7 @@ export function IconDetails({
 
 		if (isExternalIcon && externalIcon) {
 			if (externalIcon.formats.includes("svg")) {
-				variants.push({ value: "base", label: "Base Icon", iconName: externalIcon.slug })
+				variants.push({ value: "base", label: isSimpleIcons ? "Brand color" : "Base Icon", iconName: externalIcon.slug })
 			}
 			if (externalIcon.variants?.light && canResolveExternalIconUrl(externalIcon, "svg_light")) {
 				variants.push({ value: "light", label: "Light Variant", iconName: `${externalIcon.slug}-light` })
@@ -712,7 +692,7 @@ export function IconDetails({
 		}
 
 		return variants
-	}, [isExternalIcon, externalIcon, isCommunityIcon, assetUrls, mainIconUrl, icon, iconData])
+	}, [isExternalIcon, externalIcon, isSimpleIcons, isCommunityIcon, assetUrls, mainIconUrl, icon, iconData])
 
 	const getSvgUrl = useCallback(
 		(variantValue?: string): string | null => {
@@ -796,14 +776,25 @@ export function IconDetails({
 							<div className="flex flex-col items-center bg-background">
 								<div className="relative">
 									<div className="relative flex h-32 w-32 items-center justify-center rounded-xl ring-1 ring-white/5 dark:ring-white/10 bg-primary/15 dark:bg-secondary/10 overflow-hidden p-3">
-										<UnoptimizedImage
-											src={heroImageUrl}
-											priority
-											width={96}
-											height={96}
-											alt={`${formatedIconName} icon and logo in ${iconData.base.toUpperCase()} format`}
-											className="max-h-full max-w-full object-contain"
-										/>
+										{isSimpleIcons && externalIcon ? (
+											<UnoptimizedImage
+												src={resolveExternalIconUrl(externalIcon, "svg_light")}
+												priority
+												width={96}
+												height={96}
+												alt={`${formatedIconName} icon and logo`}
+												className="max-h-full max-w-full object-contain dark:invert"
+											/>
+										) : (
+											<UnoptimizedImage
+												src={heroImageUrl}
+												priority
+												width={96}
+												height={96}
+												alt={`${formatedIconName} icon and logo in ${iconData.base.toUpperCase()} format`}
+												className="max-h-full max-w-full object-contain"
+											/>
+										)}
 									</div>
 								</div>
 								<CardTitle className="text-2xl font-bold capitalize text-center mb-2">
@@ -895,8 +886,7 @@ export function IconDetails({
 											{iconData.wordmark && " Wordmark variants are also available for enhanced branding options."}
 										</p>
 										<p>
-											Perfect for adding to dashboards, app directories, documentation, or anywhere you need the {formatIconName(icon)}{" "}
-											logo.
+											Perfect for adding to dashboards, app directories, documentation, or anywhere you need the {formatedIconName} logo.
 										</p>
 										{isExternalIcon && externalSourceConfig && <p>External icon provided by {externalSourceConfig.label}.</p>}
 									</div>
@@ -904,7 +894,38 @@ export function IconDetails({
 								{isExternalIcon && externalIcon && (
 									<div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
 										<p className="font-medium text-foreground">{externalIcon.attribution}</p>
-										<p className="mt-1">License: {externalIcon.license}</p>
+										<p className="mt-1">
+											License:{" "}
+											{externalIcon.license_url && externalIcon.license ? (
+												<Link
+													href={externalIcon.license_url}
+													target="_blank"
+													rel="noopener noreferrer"
+													className="text-primary hover:underline"
+												>
+													{externalIcon.license}
+												</Link>
+											) : externalIcon.license ? (
+												externalIcon.license
+											) : externalIcon.source === "simpleicons" ? (
+												<Link
+													href={SIMPLE_ICONS_DISCLAIMER_URL}
+													target="_blank"
+													rel="noopener noreferrer"
+													className="text-primary hover:underline"
+												>
+													Not specified by Simple Icons
+												</Link>
+											) : (
+												"Not specified"
+											)}
+										</p>
+										{externalIcon.source === "simpleicons" && (
+											<p className="mt-2">
+												Brand names and marks remain subject to their owners&apos; trademark and usage terms. Check the source and brand
+												guidelines before use.
+											</p>
+										)}
 									</div>
 								)}
 							</div>
@@ -924,61 +945,44 @@ export function IconDetails({
 							<div className="space-y-10">
 								{shouldShowBaseIcon() && (
 									<IconVariantsSection
-										title="Base Icon"
-										description="Original icon version"
+										title={isSimpleIcons ? "Brand color" : "Base Icon"}
+										description={isSimpleIcons ? "Official brand color" : "Original icon version"}
 										iconElement={<FileType className="w-4 h-4 text-blue-500" />}
-										aavailableFormats={availableFormats}
+										availableFormats={availableFormats}
 										icon={icon}
 										iconData={iconData}
-										handleCopy={handleCopyUrl}
-										handleDownload={handleDownload}
-										copiedVariants={copiedVariants}
 										renderVariant={renderVariant}
 									/>
 								)}
 
 								{iconData.colors?.light && (
 									<IconVariantsSection
-										title="Light theme"
-										description="Icon variants optimized for light backgrounds (typically darker icon colors)"
+										title="Light mode"
+										description={isSimpleIcons ? "Black icon for light backgrounds" : "Icon variants optimized for light backgrounds"}
 										iconElement={<Sun className="w-4 h-4 text-amber-500" />}
-										aavailableFormats={availableFormats}
+										availableFormats={availableFormats}
 										icon={icon}
 										theme="light"
 										iconData={iconData}
-										handleCopy={handleCopyUrl}
-										handleDownload={handleDownload}
-										copiedVariants={copiedVariants}
 										renderVariant={renderVariant}
 									/>
 								)}
 
 								{iconData.colors?.dark && (
 									<IconVariantsSection
-										title="Dark theme"
-										description="Icon variants optimized for dark backgrounds (typically lighter icon colors)"
+										title="Dark mode"
+										description={isSimpleIcons ? "White icon for dark backgrounds" : "Icon variants optimized for dark backgrounds"}
 										iconElement={<Moon className="w-4 h-4 text-indigo-500" />}
-										aavailableFormats={availableFormats}
+										availableFormats={availableFormats}
 										icon={icon}
 										theme="dark"
 										iconData={iconData}
-										handleCopy={handleCopyUrl}
-										handleDownload={handleDownload}
-										copiedVariants={copiedVariants}
 										renderVariant={renderVariant}
 									/>
 								)}
 
 								{iconData.wordmark && (
-									<WordmarkSection
-										iconData={iconData}
-										icon={icon}
-										aavailableFormats={availableFormats}
-										handleCopy={handleCopyUrl}
-										handleDownload={handleDownload}
-										copiedVariants={copiedVariants}
-										renderVariant={renderVariant}
-									/>
+									<WordmarkSection iconData={iconData} icon={icon} availableFormats={availableFormats} renderVariant={renderVariant} />
 								)}
 							</div>
 						</CardContent>
@@ -1024,7 +1028,7 @@ export function IconDetails({
 									</div>
 								</div>
 
-								{iconData.colors && (
+								{iconData.colors && !isSimpleIcons && (
 									<div className="">
 										<h3 className="text-sm font-semibold text-muted-foreground mb-2">Color variants</h3>
 										<div className="space-y-2">
@@ -1032,7 +1036,7 @@ export function IconDetails({
 												<div key={theme} className="flex items-center gap-2">
 													<PaletteIcon className="w-4 h-4 text-purple-500" />
 													<span className="capitalize font-medium text-sm">{theme}:</span>
-													<code className=" border border-border px-2 py-0.5 rounded-lg text-xs">{variant}</code>
+													<code className="border border-border px-2 py-0.5 rounded-lg text-xs">{variant}</code>
 												</div>
 											))}
 										</div>
@@ -1062,15 +1066,24 @@ export function IconDetails({
 								)}
 
 								{isExternalIcon && externalIcon && externalSourceConfig && (
-									<div className="">
+									<div className="space-y-2">
 										<h3 className="text-sm font-semibold text-muted-foreground mb-2">Source</h3>
 										<Button variant="outline" className="w-full gap-2" asChild>
 											<Link href={externalIcon.source_url} target="_blank" rel="noopener noreferrer">
 												<UnoptimizedImage src={externalSourceConfig.icon} alt="" width={16} height={16} className="shrink-0" />
-												View on {externalSourceConfig.label}
+												{externalIcon.source === "simpleicons" ? "View original source" : `View on ${externalSourceConfig.label}`}
 												<ExternalLink className="w-4 h-4 ml-auto" />
 											</Link>
 										</Button>
+										{externalIcon.guidelines_url && (
+											<Button variant="outline" className="w-full gap-2" asChild>
+												<Link href={externalIcon.guidelines_url} target="_blank" rel="noopener noreferrer">
+													<FileType className="w-4 h-4" />
+													Read brand guidelines
+													<ExternalLink className="w-4 h-4 ml-auto" />
+												</Link>
+											</Button>
+										)}
 									</div>
 								)}
 

--- a/web/src/components/magicui/magic-card.tsx
+++ b/web/src/components/magicui/magic-card.tsx
@@ -1,16 +1,10 @@
 "use client"
 
 import { motion, useMotionTemplate, useMotionValue } from "motion/react"
-import { useTheme } from "next-themes"
 import type React from "react"
 import { useCallback, useEffect, useRef } from "react"
 import { cn } from "@/lib/utils"
 import { useMagicCardPointer } from "./magic-card-pointer"
-
-const THEME_BORDER_COLORS: Record<string, { from: string; to: string }> = {
-	dark: { from: "#ffb3c1", to: "#ff75a0" },
-	light: { from: "#1e9df1", to: "#8ed0f9" },
-}
 
 interface MagicCardProps {
 	children?: React.ReactNode
@@ -99,9 +93,6 @@ export function MagicCard({ children, className, gradientSize = 200, gradientCol
 		if (!isShared) resetPosition()
 	}, [isShared, resetPosition])
 
-	const { resolvedTheme } = useTheme()
-	const { from: fromColor, to: toColor } = THEME_BORDER_COLORS[resolvedTheme ?? "dark"] ?? THEME_BORDER_COLORS.dark
-
 	return (
 		<div ref={cardRef} className={cn("group relative rounded-[inherit]", className)}>
 			<motion.div
@@ -109,8 +100,8 @@ export function MagicCard({ children, className, gradientSize = 200, gradientCol
 				style={{
 					background: useMotionTemplate`
           radial-gradient(${gradientSize}px circle at ${mouseX}px ${mouseY}px,
-          ${fromColor}, 
-          ${toColor}, 
+		  var(--magic-border-from),
+		  var(--magic-border-to),
           var(--border) 100%
           )
           `,

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -10,7 +10,7 @@ export const getDescription = (totalIcons: number) =>
 
 export const websiteTitle = "Free Dashboard Icons & Logos - Download High-Quality Service Icons"
 
-export type ExternalSourceId = "selfhst" | "lobehub"
+export type ExternalSourceId = "selfhst" | "lobehub" | "simpleicons"
 
 export interface ExternalSourceConfig {
 	id: ExternalSourceId
@@ -49,6 +49,18 @@ export const EXTERNAL_SOURCES: Record<ExternalSourceId, ExternalSourceConfig> = 
 		authorUrl: "https://github.com/lobehub/lobe-icons",
 		license: "MIT",
 		pbFilter: "lobehub",
+	},
+	simpleicons: {
+		id: "simpleicons",
+		label: "Simple Icons",
+		icon: "https://cdn.simpleicons.org/simpleicons/111111/FFFFFF",
+		cdnBase: "https://cdn.simpleicons.org",
+		website: "https://simpleicons.org/",
+		authorName: "Simple Icons",
+		authorLogin: "simple-icons",
+		authorUrl: "https://github.com/simple-icons/simple-icons",
+		license: "CC0-1.0",
+		pbFilter: "simpleicons",
 	},
 }
 

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -484,7 +484,7 @@ describe("api", () => {
 					categories: ["Shared"],
 					update: { timestamp: "2020-01-01T00:00:00Z", author: { id: 1 } },
 				},
-			} as IconFile
+			} as unknown as IconFile
 
 			const related = computeRelatedIcons("current", ["Shared"], metadata)
 			expect(related[0]?.data.aliases).toEqual([])

--- a/web/src/lib/__tests__/simple-icons-importer.test.ts
+++ b/web/src/lib/__tests__/simple-icons-importer.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+import { buildSimpleIconRecords } from "../../../scripts/import-simple-icons"
+
+const upstreamIcons = [
+	{
+		title: "GitHub",
+		slug: "github",
+		hex: "181717",
+		source: "https://github.com/logos",
+		guidelines: "https://github.com/logos",
+		license: { type: "CC BY 4.0", url: "https://github.com/logos" },
+		aliases: {
+			aka: ["GitHub, Inc."],
+			dup: ["githubactions"],
+			loc: { "zh-CN": "GitHub" },
+		},
+	},
+	{
+		title: "Home Assistant",
+		slug: "homeassistant",
+		hex: "18BCF2",
+		source: "https://www.home-assistant.io/",
+		aliases: { aka: ["HASS"] },
+	},
+]
+
+describe("buildSimpleIconRecords", () => {
+	it("maps metadata plus brand, theme-aware, light, and dark SVG and PNG variants", () => {
+		const records = buildSimpleIconRecords(upstreamIcons, new Set<string>())
+
+		expect(records).toHaveLength(upstreamIcons.length)
+		expect(records[0]).toMatchObject({
+			source: "simpleicons",
+			slug: "github",
+			name: "GitHub",
+			aliases: expect.arrayContaining(["GitHub, Inc.", "githubactions"]),
+			formats: ["svg", "png"],
+			variants: { light: true, dark: true },
+			brand_color: "181717",
+			license: "CC BY 4.0",
+			attribution: "GitHub icon by Simple Icons (CC BY 4.0). Brand marks remain subject to their owners' terms.",
+			source_url: "https://github.com/logos",
+			guidelines_url: "https://github.com/logos",
+			url_templates: {
+				svg: "https://cdn.simpleicons.org/{slug}/{hex}",
+				svg_auto: "https://cdn.simpleicons.org/{slug}/000000/FFFFFF",
+				svg_light: "https://cdn.simpleicons.org/{slug}/000000",
+				svg_dark: "https://cdn.simpleicons.org/{slug}/FFFFFF",
+				png: "/api/icons/external/simpleicons/{slug}/brand.png",
+				png_light: "/api/icons/external/simpleicons/{slug}/light.png",
+				png_dark: "/api/icons/external/simpleicons/{slug}/dark.png",
+			},
+			upstream_data: expect.objectContaining({ import_schema_version: 2 }),
+		})
+	})
+
+	it("skips every slug already provided natively without dropping other upstream icons", () => {
+		const records = buildSimpleIconRecords(upstreamIcons, new Set(["homeassistant"]))
+
+		expect(records.map((record) => record.slug)).toEqual(["github"])
+	})
+
+	it("deduplicates aliases deterministically and never emits the title or slug as aliases", () => {
+		const records = buildSimpleIconRecords(
+			[
+				{
+					...upstreamIcons[0],
+					aliases: { aka: ["GitHub", "github", "GitHub, Inc.", "GitHub, Inc."], dup: ["githubactions", "githubactions"] },
+				},
+			],
+			new Set<string>(),
+		)
+
+		expect(records[0]?.aliases).toEqual(["GitHub, Inc.", "githubactions"])
+	})
+
+	it("uses per-icon license metadata without treating the collection license as an icon license", () => {
+		const records = buildSimpleIconRecords(upstreamIcons, new Set<string>())
+
+		expect(records[0]?.license).toBe("CC BY 4.0")
+		expect(records[1]?.license).toBe("")
+		expect(records[1]?.license_url).toBe("")
+		expect(records[1]?.attribution).toBe("Home Assistant icon via Simple Icons. Brand marks remain subject to their owners' terms.")
+	})
+
+	it("does not link an icon-specific license to the collection's different license text", () => {
+		const [record] = buildSimpleIconRecords([{ ...upstreamIcons[1], license: { type: "Apache-2.0" } }], new Set<string>())
+
+		expect(record?.license).toBe("Apache-2.0")
+		expect(record?.license_url).toBe("")
+		expect(record?.attribution).toContain("(Apache-2.0)")
+	})
+})

--- a/web/src/lib/__tests__/simple-icons-source.test.ts
+++ b/web/src/lib/__tests__/simple-icons-source.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import { EXTERNAL_SOURCE_IDS, EXTERNAL_SOURCES } from "@/constants"
+import { getExternalIconPreviewUrl, resolveExternalIconUrl } from "@/lib/external-icon-urls"
+import type { ExternalIcon } from "@/types/icons"
+
+const repoRoot = path.resolve(process.cwd(), "..")
+
+describe("Simple Icons external source registration", () => {
+	it("registers the official source, credit, license, logo, and CDN", () => {
+		const source = (EXTERNAL_SOURCES as Record<string, (typeof EXTERNAL_SOURCES)[keyof typeof EXTERNAL_SOURCES]>).simpleicons
+
+		expect(EXTERNAL_SOURCE_IDS).toContain("simpleicons")
+		expect(source).toMatchObject({
+			id: "simpleicons",
+			label: "Simple Icons",
+			website: "https://simpleicons.org/",
+			authorName: "Simple Icons",
+			authorLogin: "simple-icons",
+			authorUrl: "https://github.com/simple-icons/simple-icons",
+			license: "CC0-1.0",
+			pbFilter: "simpleicons",
+		})
+		expect(source.icon).toMatch(/^https:\/\/cdn\.simpleicons\.org\/simpleicons\//)
+		expect(source.cdnBase).toBe("https://cdn.simpleicons.org")
+	})
+
+	it("resolves official adaptive and static SVGs plus local rasterized PNG variants", () => {
+		const icon = {
+			source: "simpleicons",
+			slug: "github",
+			brand_color: "181717",
+			url_templates: {
+				svg: "https://cdn.simpleicons.org/{slug}/{hex}",
+				svg_auto: "https://cdn.simpleicons.org/{slug}/000000/FFFFFF",
+				svg_light: "https://cdn.simpleicons.org/{slug}/000000",
+				svg_dark: "https://cdn.simpleicons.org/{slug}/FFFFFF",
+				png: "/api/icons/external/simpleicons/{slug}/brand.png",
+				png_light: "/api/icons/external/simpleicons/{slug}/light.png",
+				png_dark: "/api/icons/external/simpleicons/{slug}/dark.png",
+			},
+		} as unknown as ExternalIcon
+
+		expect(resolveExternalIconUrl(icon, "svg")).toBe("https://cdn.simpleicons.org/github/181717")
+		expect(resolveExternalIconUrl(icon, "svg_light")).toBe("https://cdn.simpleicons.org/github/000000")
+		expect(resolveExternalIconUrl(icon, "svg_dark")).toBe("https://cdn.simpleicons.org/github/FFFFFF")
+		expect(getExternalIconPreviewUrl(icon)).toBe("https://cdn.simpleicons.org/github/000000/FFFFFF")
+		expect(resolveExternalIconUrl(icon, "png")).toBe("/api/icons/external/simpleicons/github/brand.png")
+		expect(resolveExternalIconUrl(icon, "png_light")).toBe("/api/icons/external/simpleicons/github/light.png")
+		expect(resolveExternalIconUrl(icon, "png_dark")).toBe("/api/icons/external/simpleicons/github/dark.png")
+	})
+
+	it("resolves the same URLs for compact browse records without stored templates", () => {
+		const icon = {
+			source: "simpleicons",
+			slug: "github",
+			brand_color: "181717",
+			url_templates: {},
+		} as unknown as ExternalIcon
+
+		expect(resolveExternalIconUrl(icon, "svg")).toBe("https://cdn.simpleicons.org/github/181717")
+		expect(getExternalIconPreviewUrl(icon)).toBe("https://cdn.simpleicons.org/github/000000/FFFFFF")
+		expect(resolveExternalIconUrl(icon, "svg_light")).toBe("https://cdn.simpleicons.org/github/000000")
+		expect(resolveExternalIconUrl(icon, "svg_dark")).toBe("https://cdn.simpleicons.org/github/FFFFFF")
+	})
+
+	it("does not invent an adaptive selfh.st URL", () => {
+		const icon = {
+			source: "selfhst",
+			slug: "2fauth",
+			formats: ["svg"],
+			url_templates: {},
+		} as unknown as ExternalIcon
+
+		expect(getExternalIconPreviewUrl(icon)).toBe("https://cdn.jsdelivr.net/gh/selfhst/icons/svg/2fauth.svg")
+	})
+})
+
+describe("Simple Icons persistence and scheduled sync", () => {
+	it("allows Simple Icons in the PocketBase external_icons source field", () => {
+		const migrationDir = path.join(repoRoot, "web/backend/pb_migrations")
+		const migrations = fs
+			.readdirSync(migrationDir)
+			.filter((file) => file.endsWith(".js"))
+			.map((file) => fs.readFileSync(path.join(migrationDir, file), "utf8"))
+			.join("\n")
+
+		expect(migrations).toMatch(/sourceField\.values\s*=\s*\[[\s\S]*?["']simpleicons["']/)
+		expect(migrations).toContain("findRecordsByFilter(collection, \"source = 'simpleicons'\"")
+	})
+
+	it("runs a manual and weekly authenticated Simple Icons sync", () => {
+		const workflowPath = path.join(repoRoot, ".github/workflows/sync-simple-icons.yml")
+		expect(fs.existsSync(workflowPath)).toBe(true)
+
+		const workflow = fs.readFileSync(workflowPath, "utf8")
+		expect(workflow).toContain("workflow_dispatch:")
+		// A fixed weekday (rather than `*`) makes this weekly, not daily.
+		expect(workflow).toMatch(/cron:\s*["']\d+\s+\d+\s+\*\s+\*\s+[0-6]["']/)
+		expect(workflow).toContain("bun run scripts/import-simple-icons.ts")
+		expect(workflow).toMatch(/PB_ADMIN:\s*\$\{\{ secrets\.PB_ADMIN \}\}/)
+		expect(workflow).toMatch(/PB_ADMIN_PASS:\s*\$\{\{ secrets\.PB_ADMIN_PASS \}\}/)
+	})
+
+	it("allows newly synchronized external slugs to render without a redeploy", () => {
+		const route = fs.readFileSync(path.join(repoRoot, "web/src/app/icons/external/[slug]/page.tsx"), "utf8")
+		const externalIcons = fs.readFileSync(path.join(repoRoot, "web/src/lib/external-icons.ts"), "utf8")
+
+		expect(route).toContain("export const dynamicParams = true")
+		expect(route).toContain("export const revalidate = 900")
+		expect(externalIcons).toContain('pb.filter("source = {:source} && slug = {:slug}"')
+	})
+})

--- a/web/src/lib/__tests__/svg-color-utils.test.ts
+++ b/web/src/lib/__tests__/svg-color-utils.test.ts
@@ -100,6 +100,11 @@ describe("extractColorsFromSvg", () => {
 		expect(colors).toContain("#ff0000")
 	})
 
+	it("does not add implicit black when a shape inherits the root fill", () => {
+		const svg = `<svg xmlns="http://www.w3.org/2000/svg" fill="#F58025"><path d="M0 0h24v24H0z"/></svg>`
+		expect(extractColorsFromSvg(svg)).toEqual(["#f58025"])
+	})
+
 	it("extracts stroke attribute colors", () => {
 		const svg = `<svg xmlns="http://www.w3.org/2000/svg"><rect stroke="#00ff00"/></svg>`
 		const colors = extractColorsFromSvg(svg)

--- a/web/src/lib/external-icon-urls.ts
+++ b/web/src/lib/external-icon-urls.ts
@@ -1,47 +1,57 @@
 import { EXTERNAL_SOURCES, type ExternalSourceId } from "@/constants"
-import type { ExternalIcon } from "@/types/icons"
+import type { ExternalIcon, ExternalIconUrlData } from "@/types/icons"
 
 const FALLBACK_URL_BUILDERS: Partial<
-	Record<ExternalSourceId, (cdnBase: string, slug: string, format: string, variant?: string) => string>
+	Record<ExternalSourceId, (cdnBase: string, slug: string, format: string, variant?: string, brandColor?: string) => string>
 > = {
 	selfhst: (cdnBase, slug, format, variant) => {
 		const suffix = variant ? `-${variant}` : ""
 		return `${cdnBase}/${format}/${slug}${suffix}.${format}`
 	},
+	simpleicons: (cdnBase, slug, format, variant, brandColor) => {
+		if (format === "png") return `/api/icons/external/simpleicons/${slug}/${variant || "brand"}.png`
+		if (variant === "auto") return `${cdnBase}/${slug}/000000/FFFFFF`
+		if (variant === "light") return `${cdnBase}/${slug}/000000`
+		if (variant === "dark") return `${cdnBase}/${slug}/FFFFFF`
+		return brandColor ? `${cdnBase}/${slug}/${brandColor}` : `${cdnBase}/${slug}`
+	},
 }
 
 export function canResolveExternalIconUrl(icon: Pick<ExternalIcon, "source" | "url_templates">, key: string): boolean {
 	const templates = icon.url_templates ?? {}
-	return !!templates[key] || !!FALLBACK_URL_BUILDERS[icon.source]
+	if (templates[key]) return true
+
+	switch (icon.source) {
+		case "simpleicons":
+			return /^(svg|png)(_(light|dark|auto))?$/.test(key)
+		case "selfhst":
+			return /^(svg|png|webp)(_(light|dark))?$/.test(key)
+		default:
+			return false
+	}
 }
 
-export function resolveExternalIconUrl(icon: Pick<ExternalIcon, "source" | "slug" | "url_templates">, key: string): string {
+export function resolveExternalIconUrl(icon: Pick<ExternalIcon, "source" | "slug" | "url_templates" | "brand_color">, key: string): string {
 	const templates = icon.url_templates ?? {}
 	const template = templates[key]
-	if (template) return template.replace("{slug}", icon.slug)
+	if (template) {
+		return template.replaceAll("{slug}", icon.slug).replaceAll("{hex}", icon.brand_color ?? "")
+	}
 
 	const parts = key.split("_")
 	const format = parts[0]
 	const variant = parts[1]
 	const sourceConfig = EXTERNAL_SOURCES[icon.source]
 	const buildUrl = FALLBACK_URL_BUILDERS[icon.source]
-	if (buildUrl) return buildUrl(sourceConfig?.cdnBase ?? "", icon.slug, format, variant)
+	if (buildUrl) return buildUrl(sourceConfig?.cdnBase ?? "", icon.slug, format, variant, icon.brand_color)
 
 	return `${sourceConfig?.cdnBase ?? ""}/${format}/${icon.slug}.${format}`
 }
 
-export function getExternalIconPreviewUrl(icon: ExternalIcon): string {
+export function getExternalIconPreviewUrl(icon: ExternalIconUrlData): string {
+	if (icon.url_templates?.svg_auto || icon.source === "simpleicons") return resolveExternalIconUrl(icon, "svg_auto")
+
 	const formats = icon.formats ?? []
 	const format = formats.includes("svg") ? "svg" : formats.includes("png") ? "png" : formats[0] || "svg"
 	return resolveExternalIconUrl(icon, format)
-}
-
-export function getExternalIconThemedPreviewUrl(icon: ExternalIcon, theme: "light" | "dark"): string {
-	const variants = icon.variants ?? {}
-	if (variants.light && variants.dark) {
-		const format = (icon.formats ?? []).includes("png") ? "png" : (icon.formats ?? []).includes("webp") ? "webp" : null
-		const key = format ? `${format}_${theme}` : null
-		if (key && canResolveExternalIconUrl(icon, key)) return resolveExternalIconUrl(icon, key)
-	}
-	return getExternalIconPreviewUrl(icon)
 }

--- a/web/src/lib/external-icons.ts
+++ b/web/src/lib/external-icons.ts
@@ -49,10 +49,11 @@ function toExternalIconRecord(icon: ExternalIcon, { lite = false } = {}): Extern
 				categories,
 				formats,
 				variants: icon.variants ?? {},
-				url_templates: icon.url_templates ?? {},
-				license: icon.license ?? "",
-				attribution: icon.attribution ?? "",
-				source_url: icon.source_url ?? "",
+				url_templates: icon.source === "simpleicons" ? {} : (icon.url_templates ?? {}),
+				license: "",
+				attribution: "",
+				source_url: "",
+				brand_color: icon.brand_color,
 			}
 		: { ...icon, formats, aliases, categories }
 
@@ -83,8 +84,7 @@ async function fetchExternalIconsForSource(sourceId: ExternalSourceId): Promise<
 	const sourceConfig = getExternalSource(sourceId)
 	const records = await pb.collection("external_icons").getFullList<ExternalIcon>({
 		filter: pb.filter("source = {:source}", { source: sourceConfig.pbFilter }),
-		fields:
-			"id,source,slug,name,aliases,categories,formats,variants,url_templates,license,attribution,source_url,updated_at_source,created,updated",
+		fields: "id,source,slug,name,aliases,categories,formats,variants,url_templates,brand_color,updated_at_source,created,updated",
 		batch: 500,
 		sort: "name",
 		requestKey: null,
@@ -123,26 +123,26 @@ export const getExternalIcons = cache(async (): Promise<ExternalIconRecord[]> =>
 	return fetchExternalIconsWithTTL()
 })
 
-export async function getExternalIconBySlug(slug: string): Promise<ExternalIconRecord | null> {
-	const icons = await getExternalIcons()
-	const fromList = icons.find((icon) => icon.slug === slug)
-	if (fromList) {
-		return fromList
-	}
-
-	if (icons.length === 0) {
-		return null
-	}
-
+export async function getExternalIconBySourceAndSlug(source: ExternalSourceId, slug: string): Promise<ExternalIconRecord | null> {
 	try {
 		const pb = createServerPB()
-		const record = await pb.collection("external_icons").getFirstListItem<ExternalIcon>(pb.filter("slug = {:slug}", { slug }), {
-			requestKey: null,
-		})
+		const record = await pb
+			.collection("external_icons")
+			.getFirstListItem<ExternalIcon>(pb.filter("source = {:source} && slug = {:slug}", { source, slug }), { requestKey: null })
 		return toExternalIconRecord(record)
 	} catch {
 		return null
 	}
+}
+
+export async function getExternalIconBySlug(slug: string): Promise<ExternalIconRecord | null> {
+	const icons = await getExternalIcons()
+	const fromList = icons.find((icon) => icon.slug === slug)
+	if (!fromList) {
+		return null
+	}
+
+	return getExternalIconBySourceAndSlug(fromList.source, slug)
 }
 
 export const getExternalIcon = getExternalIconBySlug

--- a/web/src/lib/icon-url.ts
+++ b/web/src/lib/icon-url.ts
@@ -1,13 +1,13 @@
 import { getExternalIconPreviewUrl } from "@/lib/external-icon-urls"
 import { buildIconUrl, type IconFormat } from "@/lib/icons/urls"
-import type { IconWithName } from "@/types/icons"
+import type { IconSearchEntry } from "@/types/icons"
 
-function resolveFormat(base: IconWithName["data"]["base"]): IconFormat {
+function resolveFormat(base: IconSearchEntry["data"]["base"]): IconFormat {
 	if (base === "png" || base === "webp") return base
 	return "svg"
 }
 
-export function getIconImageUrl(icon: IconWithName): string {
+export function getIconImageUrl(icon: IconSearchEntry): string {
 	if (icon.source && icon.source !== "native" && icon.external) {
 		return getExternalIconPreviewUrl(icon.external)
 	}

--- a/web/src/lib/icons/search.ts
+++ b/web/src/lib/icons/search.ts
@@ -1,4 +1,4 @@
-import type { IconWithName } from "@/types/icons"
+import type { IconSearchEntry } from "@/types/icons"
 
 const NAME_WEIGHT = 2.0
 const ALIAS_WEIGHT = 1.5
@@ -105,26 +105,26 @@ export function fuzzySearch(text: string, query: string): number {
 
 export type SortOption = "relevance" | "alphabetical-asc" | "alphabetical-desc" | "newest"
 
-export function scoreIcon(icon: IconWithName, query: string): number {
+export function scoreIcon(icon: IconSearchEntry, query: string): number {
 	const nameScore = fuzzySearch(icon.name, query) * NAME_WEIGHT
 	const aliasScore =
 		icon.data.aliases.length > 0 ? Math.max(...icon.data.aliases.map((alias) => fuzzySearch(alias, query))) * ALIAS_WEIGHT : 0
 	return Math.max(nameScore, aliasScore)
 }
 
-export function filterAndSortIcons({
+export function filterAndSortIcons<T extends IconSearchEntry>({
 	icons,
 	query = "",
 	categories = [],
 	sort = "relevance",
 	limit,
 }: {
-	icons: IconWithName[]
+	icons: T[]
 	query?: string
 	categories?: string[]
 	sort?: SortOption
 	limit?: number
-}): IconWithName[] {
+}): T[] {
 	let filtered = icons
 
 	if (categories.length > 0) {
@@ -167,7 +167,7 @@ export function filterAndSortIcons({
 			.filter((item) => item.score > 0.7)
 			.sort((a, b) => {
 				if (b.score !== a.score) return b.score - a.score
-				const externalRank = (icon: IconWithName) => Number(Boolean(icon.source && icon.source !== "native"))
+				const externalRank = (icon: IconSearchEntry) => Number(Boolean(icon.source && icon.source !== "native"))
 				const rankDiff = externalRank(a.icon) - externalRank(b.icon)
 				if (rankDiff !== 0) return rankDiff
 				return a.icon.name.localeCompare(b.icon.name)
@@ -176,7 +176,7 @@ export function filterAndSortIcons({
 		filtered = scored.map((item) => item.icon)
 	}
 
-	const nativeFirst = (a: IconWithName, b: IconWithName) => {
+	const nativeFirst = (a: IconSearchEntry, b: IconSearchEntry) => {
 		const aExt = a.source && a.source !== "native" ? 1 : 0
 		const bExt = b.source && b.source !== "native" ? 1 : 0
 		return aExt - bExt

--- a/web/src/lib/svg-color-utils.ts
+++ b/web/src/lib/svg-color-utils.ts
@@ -365,6 +365,18 @@ export function extractColorsFromSvg(svg: string): string[] {
 		const SHAPE_TAGS = new Set(["path", "rect", "circle", "ellipse", "polygon", "polyline", "line", "text"])
 
 		let hasImplicitBlack = false
+		const hasValidInheritedFill = (element: Element): boolean => {
+			let ancestor = element.parentElement
+			while (ancestor) {
+				const fill = ancestor.getAttribute("fill")
+				if (fill && normalizeColor(fill)) return true
+
+				const styleFill = ancestor.getAttribute("style")?.match(/(?<!\w-)fill\s*:\s*([^;]+)/i)?.[1]
+				if (styleFill && normalizeColor(styleFill)) return true
+				ancestor = ancestor.parentElement
+			}
+			return false
+		}
 
 		const extractFromElement = (element: Element) => {
 			for (const attr of COLOR_ATTRS) {
@@ -380,6 +392,7 @@ export function extractColorsFromSvg(svg: string): string[] {
 			if (
 				SHAPE_TAGS.has(element.tagName.toLowerCase()) &&
 				!element.getAttribute("fill") &&
+				!hasValidInheritedFill(element) &&
 				!element.closest("clipPath") &&
 				!element.closest("mask")
 			) {

--- a/web/src/types/icons.ts
+++ b/web/src/types/icons.ts
@@ -43,6 +43,16 @@ export type IconWithName = {
 	external?: ExternalIcon
 }
 
+export type ExternalIconUrlData = Pick<ExternalIcon, "source" | "slug" | "formats" | "url_templates" | "brand_color">
+
+export type IconSearchEntry = {
+	name: string
+	data: Pick<Icon, "base" | "aliases" | "categories"> & Partial<Pick<Icon, "update">>
+	source?: "native" | ExternalSourceId
+	slug?: string
+	external?: ExternalIconUrlData
+}
+
 export type IconSearchProps = {
 	icons: IconRecord[]
 	initialQuery?: string
@@ -73,8 +83,14 @@ export type ExternalIcon = {
 	}
 	url_templates: ExternalIconUrlTemplates
 	license: string
+	license_url?: string
 	attribution: string
 	source_url: string
+	guidelines_url?: string
+	brand_color?: string
+	stable_svg_url?: string
+	upstream_version?: string
+	upstream_data?: Record<string, unknown>
 	updated_at_source?: string
 	created?: string
 	updated?: string

--- a/web/tests/external-icons.spec.ts
+++ b/web/tests/external-icons.spec.ts
@@ -111,6 +111,93 @@ test.describe("External LobeHub icons", () => {
 	})
 })
 
+test.describe("External Simple Icons", () => {
+	test("source filter makes the complete Simple Icons catalogue searchable", async ({ page }) => {
+		await page.goto("/icons?source=simpleicons&q=stackoverflow")
+		await expect(page.getByRole("button", { name: /simple icons/i })).toBeVisible()
+
+		const stackOverflowCard = page.locator('a[href="/icons/external/stackoverflow"]')
+		await expect(stackOverflowCard).toBeVisible()
+	})
+
+	test("source badge keeps its icon and label inside the hover surface", async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name === "mobile-chrome", "Touch devices do not expose hover-only source badges")
+		await page.goto("/icons?source=simpleicons&q=stackoverflow")
+
+		const card = page.locator('a[href="/icons/external/stackoverflow"]').locator("../..")
+		const badgeLabel = card.getByText("from Simple Icons")
+		await card.hover()
+		await expect(badgeLabel).toBeVisible()
+
+		const badge = badgeLabel.locator("..")
+		const isContained = await badge.evaluate((element) => {
+			const container = element.getBoundingClientRect()
+			return [...element.children].every((child) => {
+				const bounds = child.getBoundingClientRect()
+				return bounds.left >= container.left && bounds.right <= container.right && bounds.top >= container.top && bounds.bottom <= container.bottom
+			})
+		})
+		expect(isContained).toBe(true)
+	})
+
+	test("detail page credits Simple Icons and uses its brand-color CDN asset", async ({ page }) => {
+		await page.goto("/icons/external/stackoverflow")
+
+		await expect(page.getByRole("heading", { name: /stack overflow/i })).toBeVisible()
+		await expect(page.getByText(/stack overflow icon by simple icons \(cc0-1\.0\)/i)).toBeVisible()
+		await expect(page.getByText(/brand color: #f58025/i)).toHaveCount(0)
+		await expect(page.getByRole("link", { name: /view original source/i })).toHaveAttribute(
+			"href",
+			"https://stackoverflow.design/brand/logo/",
+		)
+		await expect(page.locator('img[src="https://cdn.simpleicons.org/stackoverflow/F58025"]').first()).toBeVisible()
+	})
+
+	test("offers brand, light, and dark variants in SVG and PNG", async ({ page }) => {
+		await page.goto("/icons/external/stackoverflow")
+
+		await expect(page.getByRole("heading", { name: "Brand color" })).toBeVisible()
+		await expect(page.getByRole("heading", { name: "Light mode" })).toBeVisible()
+		await expect(page.getByRole("heading", { name: "Dark mode" })).toBeVisible()
+		await expect(page.locator('img[src="https://cdn.simpleicons.org/stackoverflow/000000"]').first()).toBeVisible()
+		await expect(page.locator('img[src="https://cdn.simpleicons.org/stackoverflow/FFFFFF"]')).toBeVisible()
+		await expect(page.locator('img[src="/api/icons/external/simpleicons/stackoverflow/brand.png"]')).toBeVisible()
+		await expect(page.locator('img[src="/api/icons/external/simpleicons/stackoverflow/light.png"]')).toBeVisible()
+		await expect(page.locator('img[src="/api/icons/external/simpleicons/stackoverflow/dark.png"]')).toBeVisible()
+		await expect(page.getByRole("button", { name: /show svg downloads/i })).toHaveCount(0)
+		await expect(page.getByRole("button", { name: /show png downloads/i })).toHaveCount(0)
+
+		const png = await page.request.get("/api/icons/external/simpleicons/stackoverflow/brand.png")
+		expect(png.ok()).toBe(true)
+		expect(png.headers()["content-type"]).toContain("image/png")
+		expect((await png.body()).subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a")
+	})
+
+	test("main preview follows the site theme", async ({ page }) => {
+		await page.addInitScript(() => window.localStorage.setItem("theme", "light"))
+		await page.goto("/icons/external/stackoverflow")
+
+		const preview = page.locator('img[src="https://cdn.simpleicons.org/stackoverflow/000000"]').first()
+		await expect(preview).toBeVisible()
+		await expect(preview).toHaveCSS("filter", "none")
+
+		await page.getByRole("button", { name: "Toggle theme" }).click()
+		await page.getByRole("menuitem", { name: "Dark" }).click()
+		await expect(preview).toBeVisible()
+		await expect(preview).toHaveCSS("filter", "invert(1)")
+	})
+
+	test("brand-colored SVG remains available to the existing customizer", async ({ page }) => {
+		await page.goto("/icons/external/stackoverflow")
+
+		await page.getByRole("button", { name: /customize/i }).click()
+		await expect(page.getByText(/customize colors/i)).toBeVisible()
+		const colorControls = page.getByRole("button", { name: /hsl\(/i })
+		await expect(colorControls).toHaveCount(1)
+		await expect(colorControls.first()).toHaveAccessibleName(/hsl\(26, 91%, 55%\)/i)
+	})
+})
+
 test.describe("External icon card hover behavior", () => {
 	test("source badge appears on hover for external icons", async ({ page }) => {
 		await page.goto("/icons?source=lobehub")


### PR DESCRIPTION
Adds Simple Icons as an external source with brand, black, and white SVG/PNG variants, official attribution and guidelines, and a weekly production sync.\n\nValidated with Biome, TypeScript, and 1,046 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Simple Icons as an external icon source with searchable brand icons.
  * Added SVG and PNG variants, including light, dark, and brand presentations.
  * Added theme-aware previews, customizer color support, attribution, licensing details, source links, and optional brand guidelines.
  * Newly synchronized icons can appear automatically without requiring a full application update.

* **Bug Fixes**
  * Improved SVG color detection when colors are inherited from parent elements.
  * Improved icon URL validation and variant handling.

* **Documentation**
  * Documented Simple Icons licensing, attribution, CDN usage, variants, synchronization, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->