### PR TITLE
fix(web): ensure Simple Icons sync schema

### DIFF
--- a/web/scripts/import-simple-icons.ts
+++ b/web/scripts/import-simple-icons.ts
@@ -36,6 +36,51 @@ type BuildOptions = {
 	publishedAt?: string | null
 }
 
+type CollectionField = Record<string, unknown> & {
+	name?: string
+	values?: unknown
+}
+
+type CollectionSchema = {
+	id: string
+	fields: CollectionField[]
+}
+
+const SIMPLE_ICONS_FIELDS: CollectionField[] = [
+	{ name: "brand_color", type: "text", pattern: "^[0-9A-Fa-f]{6}$" },
+	{ name: "guidelines_url", type: "url" },
+	{ name: "license_url", type: "url" },
+	{ name: "stable_svg_url", type: "url" },
+	{ name: "upstream_version", type: "text" },
+	{ name: "upstream_data", type: "json" },
+]
+
+export function mergeSimpleIconsSchemaFields(fields: CollectionField[]): CollectionField[] {
+	const sourceIndex = fields.findIndex((field) => field.name === "source")
+	if (sourceIndex === -1) throw new Error("external_icons source field is missing")
+
+	const merged = [...fields]
+	const sourceField = merged[sourceIndex]
+	const sourceValues = Array.isArray(sourceField.values)
+		? sourceField.values.filter((value): value is string => typeof value === "string")
+		: []
+	if (!sourceValues.includes(SOURCE)) merged[sourceIndex] = { ...sourceField, values: [...sourceValues, SOURCE] }
+
+	const existingNames = new Set(merged.map((field) => field.name))
+	for (const field of SIMPLE_ICONS_FIELDS) {
+		if (!existingNames.has(field.name)) merged.push(field)
+	}
+	return merged
+}
+
+async function ensureSimpleIconsSchema(pb: PocketBase): Promise<void> {
+	const collection = await pb.collections.getOne<CollectionSchema>("external_icons")
+	const fields = mergeSimpleIconsSchemaFields(collection.fields)
+	if (JSON.stringify(fields) !== JSON.stringify(collection.fields)) {
+		await pb.collections.update(collection.id, { fields })
+	}
+}
+
 function normalizeAlias(value: string): string {
 	return value.trim()
 }
@@ -172,6 +217,7 @@ async function main() {
 	const pbUrl = process.env.NEXT_PUBLIC_POCKETBASE_URL || process.env.PB_URL || "http://127.0.0.1:8090"
 	const pb = new PocketBase(pbUrl)
 	await pb.collection("_superusers").authWithPassword(adminEmail, adminPassword)
+	await ensureSimpleIconsSchema(pb)
 
 	const current = await pb.collection("external_icons").getFullList({
 		fields: "id,source,slug,upstream_version,upstream_data,updated_at_source",

--- a/web/src/lib/__tests__/simple-icons-importer.test.ts
+++ b/web/src/lib/__tests__/simple-icons-importer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildSimpleIconRecords } from "../../../scripts/import-simple-icons"
+import { buildSimpleIconRecords, mergeSimpleIconsSchemaFields } from "../../../scripts/import-simple-icons"
 
 const upstreamIcons = [
 	{
@@ -89,5 +89,28 @@ describe("buildSimpleIconRecords", () => {
 		expect(record?.license).toBe("Apache-2.0")
 		expect(record?.license_url).toBe("")
 		expect(record?.attribution).toContain("(Apache-2.0)")
+	})
+})
+
+describe("mergeSimpleIconsSchemaFields", () => {
+	it("adds the source option and missing production fields without changing existing fields", () => {
+		const fields = [
+			{ id: "source-id", name: "source", type: "select", values: ["selfhst", "lobehub"] },
+			{ id: "slug-id", name: "slug", type: "text", required: true },
+		]
+
+		const merged = mergeSimpleIconsSchemaFields(fields)
+
+		expect(merged[0]).toEqual({ ...fields[0], values: ["selfhst", "lobehub", "simpleicons"] })
+		expect(merged[1]).toBe(fields[1])
+		expect(merged.slice(2).map((field) => field.name)).toEqual([
+			"brand_color",
+			"guidelines_url",
+			"license_url",
+			"stable_svg_url",
+			"upstream_version",
+			"upstream_data",
+		])
+		expect(mergeSimpleIconsSchemaFields(merged)).toEqual(merged)
 	})
 })


### PR DESCRIPTION
Ensures the authenticated sync creates its required PocketBase fields before importing, so separately deployed backends persist metadata and repeated runs short-circuit.\n\nValidated against a fresh old-schema PocketBase plus Biome, TypeScript, and 1,047 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Simple Icons imports by automatically synchronizing required collection fields.
  * Ensured imported icons are correctly identified as coming from the Simple Icons source.
  * Preserved existing collection settings while adding any missing required fields.

* **Bug Fixes**
  * Added validation to detect when the source field is unavailable during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->