### PR TITLE
fix: use jsDelivr for Simple Icons PNG rasterization

### DIFF
--- a/web/src/app/api/icons/external/simpleicons/[slug]/[variant]/route.tsx
+++ b/web/src/app/api/icons/external/simpleicons/[slug]/[variant]/route.tsx
@@ -1,30 +1,30 @@
-import { resolveExternalIconUrl } from "@/lib/external-icon-urls"
 import { getExternalIconBySourceAndSlug } from "@/lib/external-icons"
 import { rasterizeRemoteSvg } from "@/lib/rasterize-svg"
 
 const PNG_SIZE = 640
-const VARIANT_KEYS = {
-	brand: "svg",
-	light: "svg_light",
-	dark: "svg_dark",
-} as const
+const SIMPLE_ICONS_SVG_CDN = "https://cdn.jsdelivr.net/npm/simple-icons@latest/icons"
+
+const VARIANT_FILLS: Record<string, (brandColor?: string) => string | undefined> = {
+	brand: (brandColor) => (brandColor ? `#${brandColor}` : undefined),
+	light: () => "#000000",
+	dark: () => "#FFFFFF",
+}
 
 export async function GET(_request: Request, { params }: { params: Promise<{ slug: string; variant: string }> }) {
 	const { slug, variant: rawVariant } = await params
-	const variant = rawVariant.replace(/\.png$/, "") as keyof typeof VARIANT_KEYS
-	const svgKey = VARIANT_KEYS[variant]
+	const variant = rawVariant.replace(/\.png$/, "")
+	const getFill = VARIANT_FILLS[variant]
 
-	if (!svgKey) return new Response("Unknown Simple Icons color variant", { status: 400 })
+	if (!getFill) return new Response("Unknown Simple Icons color variant", { status: 400 })
 
 	const icon = await getExternalIconBySourceAndSlug("simpleicons", slug)
 	if (!icon) return new Response("Simple Icon not found", { status: 404 })
 
-	// Keep this server-side fetch pinned to the official Simple Icons CDN even if
-	// a stored URL template is accidentally or maliciously changed.
-	const svgUrl = resolveExternalIconUrl({ ...icon.external, url_templates: {} }, svgKey)
+	const svgUrl = `${SIMPLE_ICONS_SVG_CDN}/${slug}.svg`
+	const fillColor = getFill(icon.external.brand_color)
 
 	try {
-		const png = await rasterizeRemoteSvg(svgUrl, PNG_SIZE)
+		const png = await rasterizeRemoteSvg(svgUrl, PNG_SIZE, fillColor)
 		return new Response(png, {
 			headers: {
 				"Content-Type": "image/png",

--- a/web/src/app/api/icons/external/simpleicons/__tests__/route.test.ts
+++ b/web/src/app/api/icons/external/simpleicons/__tests__/route.test.ts
@@ -25,10 +25,27 @@ describe("Simple Icons PNG route", () => {
 			params: Promise.resolve({ slug: "github", variant: "light.png" }),
 		})
 
-		expect(mockRasterizeRemoteSvg).toHaveBeenCalledWith("https://cdn.simpleicons.org/github/000000", 640)
+		expect(mockRasterizeRemoteSvg).toHaveBeenCalledWith(
+			"https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/github.svg",
+			640,
+			"#000000",
+		)
 		expect(response.status).toBe(200)
 		expect(response.headers.get("Content-Type")).toBe("image/png")
 		expect(new Uint8Array(await response.arrayBuffer())).toEqual(Uint8Array.from([137, 80, 78, 71]))
+	})
+
+	it("applies brand color for the brand variant", async () => {
+		const { GET } = await import("../[slug]/[variant]/route")
+		await GET(new Request("http://localhost"), {
+			params: Promise.resolve({ slug: "github", variant: "brand.png" }),
+		})
+
+		expect(mockRasterizeRemoteSvg).toHaveBeenCalledWith(
+			"https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/github.svg",
+			640,
+			"#181717",
+		)
 	})
 
 	it("returns a controlled error when the upstream SVG cannot be loaded", async () => {

--- a/web/src/lib/rasterize-svg.ts
+++ b/web/src/lib/rasterize-svg.ts
@@ -1,11 +1,16 @@
 import "server-only"
 import sharp from "sharp"
 
-export async function rasterizeRemoteSvg(url: string, size: number): Promise<ArrayBuffer> {
+export async function rasterizeRemoteSvg(url: string, size: number, fillColor?: string): Promise<ArrayBuffer> {
 	const response = await fetch(url)
 	if (!response.ok) throw new Error(`Failed to fetch SVG (${response.status})`)
 
-	const png = await sharp(Buffer.from(await response.arrayBuffer()))
+	let svg = await response.text()
+	if (fillColor) {
+		svg = svg.replace("<svg", `<svg fill="${fillColor}"`)
+	}
+
+	const png = await sharp(Buffer.from(svg))
 		.resize(size, size, { fit: "contain" })
 		.png()
 		.toBuffer()


### PR DESCRIPTION
## Summary

- **Root cause**: `cdn.simpleicons.org` now returns HTTP 403 for server-side fetches due to Cloudflare bot protection, breaking all Simple Icons PNG generation (not just Corsair)
- **Fix**: Switch to `cdn.jsdelivr.net/npm/simple-icons@latest/icons/{slug}.svg` which serves raw SVGs without bot protection, and apply fill color directly to the SVG before rasterizing with sharp
- **Scope**: Affects the PNG API route at `/api/icons/external/simpleicons/[slug]/[variant].png` and the shared `rasterizeRemoteSvg` utility

## Test plan

- [x] All 1053 existing unit tests pass
- [x] Verified `cdn.simpleicons.org` returns 403 for both `corsair` and `react` slugs (confirms this affects all Simple Icons, not just Corsair)
- [x] Verified `cdn.jsdelivr.net/npm/simple-icons@latest/icons/corsair.svg` returns 200 with valid SVG
- [x] Tested full rasterization pipeline locally: fetch SVG → inject fill color → sharp resize → valid PNG output (26KB, correct magic bytes)
- [x] Confirmed broken state on live site via agent-browser screenshot

Closes #2896

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External Simple Icons PNG rendering now supports brand, light, and dark color variants.
  * Brand variants use official brand colors; light variants render in black, and dark variants render in white.

* **Bug Fixes**
  * Improved color application when converting external icons to PNG.
  * Missing icons and unsupported variants continue to return their existing error responses.
  * Invalid icon color values continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->