### PR TITLE
fix(web): keep icon detail previews consistently large

### DIFF
--- a/web/src/components/icon-details.tsx
+++ b/web/src/components/icon-details.tsx
@@ -775,7 +775,7 @@ export function IconDetails({
 						<CardHeader className="pb-2">
 							<div className="flex flex-col items-center bg-background">
 								<div className="relative w-full">
-									<div className="relative flex aspect-square w-full max-w-md items-center justify-center rounded-xl ring-1 ring-white/5 dark:ring-white/10 bg-primary/15 dark:bg-secondary/10 overflow-hidden p-3">
+									<div className="relative mx-auto flex aspect-square w-full max-w-md items-center justify-center rounded-xl ring-1 ring-white/5 dark:ring-white/10 bg-primary/15 dark:bg-secondary/10 overflow-hidden p-3">
 										{isSimpleIcons && externalIcon ? (
 											<UnoptimizedImage
 												src={resolveExternalIconUrl(externalIcon, "svg_light")}

--- a/web/src/components/icon-details.tsx
+++ b/web/src/components/icon-details.tsx
@@ -774,7 +774,7 @@ export function IconDetails({
 					<Card className="h-full gap-2 bg-background/50 border shadow-lg">
 						<CardHeader className="pb-2">
 							<div className="flex flex-col items-center bg-background">
-								<div className="relative">
+								<div className="relative w-full">
 									<div className="relative flex aspect-square w-full max-w-md items-center justify-center rounded-xl ring-1 ring-white/5 dark:ring-white/10 bg-primary/15 dark:bg-secondary/10 overflow-hidden p-3">
 										{isSimpleIcons && externalIcon ? (
 											<UnoptimizedImage


### PR DESCRIPTION
## Summary
- keep the icon detail hero preview wrapper full width
- prevent intrinsic SVG dimensions from collapsing the top-left preview

## Validation
- `pnpm exec biome check src/components/icon-details.tsx`
- browser-agent local checks for 1password, activepieces, apache-superset, azure-container-instances, and breachlab
- all five hero squares measured 236x236 with zero broken images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Centered the hero image within its container while preserving its existing size and positioning behavior.
  * Improved visual alignment across supported screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->