### PR TITLE
fix: blacklist American Express icon

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -50,6 +50,7 @@ next-env.d.ts
 backend/pocketbase
 backend/pb_data
 scripts/*
+!scripts/icon-blacklist.ts
 !scripts/import-selfhst.ts
 !scripts/import-lobehub.ts
 !scripts/import-simple-icons.ts

--- a/web/scripts/icon-blacklist.ts
+++ b/web/scripts/icon-blacklist.ts
@@ -1,0 +1,7 @@
+export const BLACKLISTED_ICONS = ["american-express", "americanexpress"]
+
+const normalizedBlacklist = new Set(BLACKLISTED_ICONS.map((slug) => slug.toLocaleLowerCase()))
+
+export function isBlacklistedIcon(slug: string): boolean {
+	return normalizedBlacklist.has(slug.trim().toLocaleLowerCase())
+}

--- a/web/scripts/import-selfhst.ts
+++ b/web/scripts/import-selfhst.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs"
 import path from "node:path"
 import PocketBase from "pocketbase"
+import { isBlacklistedIcon } from "./icon-blacklist"
 
 type SelfhstIndexRow = {
 	Name?: string
@@ -152,15 +153,25 @@ async function main() {
 		fields: "id,slug",
 		requestKey: null,
 	})
-	const existingBySlug = new Map(existingRecords.map((r) => [r.slug as string, r.id as string]))
-
 	let created = 0
 	let updated = 0
 	let skipped = 0
+	let removed = 0
+	const existingBySlug = new Map<string, string>()
+
+	for (const record of existingRecords) {
+		const slug = String(record.slug)
+		if (isBlacklistedIcon(slug)) {
+			await pb.collection("external_icons").delete(record.id)
+			removed++
+			continue
+		}
+		existingBySlug.set(slug, String(record.id))
+	}
 
 	for (const row of consolidatedRows) {
 		const record = toRecord(consolidatedToIndexRow(row, createdAtBySlug.get(row[1])))
-		if (!record) {
+		if (!record || isBlacklistedIcon(record.slug)) {
 			skipped++
 			continue
 		}
@@ -175,7 +186,7 @@ async function main() {
 		}
 	}
 
-	console.log(`selfh.st import complete: ${created} created, ${updated} updated, ${skipped} skipped`)
+	console.log(`selfh.st import complete: ${created} created, ${updated} updated, ${removed} removed, ${skipped} skipped`)
 }
 
 main().catch((error) => {

--- a/web/scripts/import-simple-icons.ts
+++ b/web/scripts/import-simple-icons.ts
@@ -2,9 +2,9 @@ import fs from "node:fs"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import PocketBase from "pocketbase"
+import { BLACKLISTED_ICONS } from "./icon-blacklist"
 
 const SOURCE = "simpleicons"
-const BLACKLISTED_ICONS = ["american-express", "americanexpress"]
 const DISCLAIMER_URL = "https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md"
 const DEFAULT_MANIFEST = "data/sources/simpleicons/simple-icons.json"
 const IMPORT_SCHEMA_VERSION = 2

--- a/web/scripts/import-simple-icons.ts
+++ b/web/scripts/import-simple-icons.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url"
 import PocketBase from "pocketbase"
 
 const SOURCE = "simpleicons"
+const BLACKLISTED_ICONS = ["american-express"]
 const DISCLAIMER_URL = "https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md"
 const DEFAULT_MANIFEST = "data/sources/simpleicons/simple-icons.json"
 const IMPORT_SCHEMA_VERSION = 2
@@ -233,7 +234,7 @@ async function main() {
 		return
 	}
 
-	const excludedSlugs = readNativeSlugs()
+	const excludedSlugs = new Set([...readNativeSlugs(), ...BLACKLISTED_ICONS])
 	for (const record of current) {
 		if (record.source !== SOURCE) excludedSlugs.add(String(record.slug).toLocaleLowerCase())
 	}

--- a/web/scripts/import-simple-icons.ts
+++ b/web/scripts/import-simple-icons.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url"
 import PocketBase from "pocketbase"
 
 const SOURCE = "simpleicons"
-const BLACKLISTED_ICONS = ["american-express"]
+const BLACKLISTED_ICONS = ["american-express", "americanexpress"]
 const DISCLAIMER_URL = "https://github.com/simple-icons/simple-icons/blob/develop/DISCLAIMER.md"
 const DEFAULT_MANIFEST = "data/sources/simpleicons/simple-icons.json"
 const IMPORT_SCHEMA_VERSION = 2


### PR DESCRIPTION
## Summary
- define one shared blacklist for `american-express` and `americanexpress`
- apply it to both Simple Icons and selfh.st imports
- delete existing blacklisted selfh.st records during sync
- keep Simple Icons cleanup behavior so existing blacklisted records are removed there too

## Verification
- focused Bun check for blacklist normalization and both slug variants
- `git diff --check`
- Biome skipped these script paths because they are excluded by repository configuration
- no tests added or run